### PR TITLE
Fix to compilation errors

### DIFF
--- a/TUIO/OneEuroFilter.cpp
+++ b/TUIO/OneEuroFilter.cpp
@@ -17,6 +17,7 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#define _USE_MATH_DEFINES
 #include "OneEuroFilter.h"
 
 using namespace TUIO;

--- a/TUIO/TcpReceiver.cpp
+++ b/TUIO/TcpReceiver.cpp
@@ -26,7 +26,7 @@ int tcp_connect(int socket, const struct sockaddr *address, socklen_t address_le
 	return connect(socket, address, address_len);
 }
 
-#if defined (WIN32) && !defined (int32_t)
+#if defined (WIN32) && not defined (int32_t)
 typedef	DWORD int32_t;
 #endif
 


### PR DESCRIPTION
In my attempts to compile the rep on Windows I've had two compilation errors

1. `#if defined (WIN32) && !defined (int32_t)` in `TcpReciever.cpp` causes a redefinition error for `int32_t` . Replacing `!` with `not` fixes this.
2. `M_PI` in `OneEuroFilter.cpp` is undefined (cmath is included in the header file). Adding `#define _USE_MATH_DEFINES` to the top of `OneEuroFilter.cpp` fixes this as well.