### PR TITLE
[fix] stop worker thread properly on TuioClient disconnect (win only)

### DIFF
--- a/TUIO/UdpReceiver.cpp
+++ b/TUIO/UdpReceiver.cpp
@@ -77,11 +77,15 @@ void UdpReceiver::disconnect() {
 		locked = false;
 		return;
 	}
-	socket->Break();
+	socket->AsynchronousBreak();
 	
 	if (!locked) {
 #ifdef WIN32
-		if( thread ) CloseHandle( thread );
+		if( thread ) 
+		{
+			WaitForSingleObject(thread, INFINITE);
+			CloseHandle(thread);
+		}
 #endif
 		thread = 0;
 	} else locked = false;


### PR DESCRIPTION
I think there is one major disadvantage of TuioClient::disconnect().
It's not synchronous. So after it returns there is no guarantee that client has disconnected.
This can lead in undesirable consequences. For example, take a look at this snippet:

```
std::unique_ptr<TUIO::TuioClient> tuioClient = std::make_unique<TUIO::TuioClient>();
tuioClient->connect();
/// later...
tuioClient->disconnect();
tuioClient.reset()
```
This snippet can lead to segfault or zombie working thread because of TuioClient destructor call and internal structures cleanup while the working thread is still running.

This PR makes TuioClient::disconnect() synchronous. The main idea is that we use https://github.com/mkalten/TUIO11_CPP/blob/7d5dd6d4e2b8e7369c932e032f500e1b3254fd1d/oscpack/ip/win32/UdpSocket.cpp#L499 to stop the thread. It raises _breakEvent in https://github.com/mkalten/TUIO11_CPP/blob/7d5dd6d4e2b8e7369c932e032f500e1b3254fd1d/oscpack/ip/win32/UdpSocket.cpp#L502 which in turn helps us to force immediate break from the working thread polling loop:
https://github.com/mkalten/TUIO11_CPP/blob/7d5dd6d4e2b8e7369c932e032f500e1b3254fd1d/oscpack/ip/win32/UdpSocket.cpp#L448
and after we wait for thread finish using WaitForSingleObject().

Using just https://github.com/mkalten/TUIO11_CPP/blob/7d5dd6d4e2b8e7369c932e032f500e1b3254fd1d/oscpack/ip/win32/UdpSocket.cpp#L494 leads to wait forever for new data on sockets and just break after, but what if we deinitialize network in other non-worker thread? (to be concrete ~TuioClient() calls https://github.com/mkalten/TUIO11_CPP/blob/7d5dd6d4e2b8e7369c932e032f500e1b3254fd1d/oscpack/ip/win32/NetworkingUtils.cpp#L74 in the chain of destructors and this leads to zombie thread that will never return from https://github.com/mkalten/TUIO11_CPP/blob/7d5dd6d4e2b8e7369c932e032f500e1b3254fd1d/oscpack/ip/win32/UdpSocket.cpp#L448).

This edit is just for Win because I have no opportunity to test it on Unix... 

Feel free to comment. 
Ivan
