### PR TITLE
[update] add an extension to pass geometry (contour) with TuioBlob

### DIFF
--- a/TUIO/OscSender.h
+++ b/TUIO/OscSender.h
@@ -76,6 +76,11 @@ namespace TUIO {
 		 * @return the maximum bundle size in bytes
 		 */
 		int getBufferSize () { return buffer_size; };
+
+		/**
+		 * This method sets the maximum bundle size in bytes
+		 */
+		virtual void setBufferSize(unsigned int size) {}
 	
 		virtual const char* tuio_type() = 0;
 		

--- a/TUIO/TuioBlob.cpp
+++ b/TUIO/TuioBlob.cpp
@@ -194,8 +194,25 @@ float TuioBlob::getRotationAccel() const{
 	return rotation_accel;
 }
 
+const std::vector<TuioBlob::Point>& TuioBlob::getGeometry() const
+{
+	return geometry;
+}
+
+void TuioBlob::updateGeometry(const TuioTime& ttime, const std::vector<TuioBlob::Point>& g)
+{
+	currentTime = ttime;
+
+	if (geometry != g)
+	{
+		geometry = g;
+
+		if (state == TUIO_STOPPED) state = TUIO_GEOMETRYCHANGED;
+	}
+}
+
 bool TuioBlob::isMoving() const{ 
-	if ((state==TUIO_ACCELERATING) || (state==TUIO_DECELERATING) || (state==TUIO_ROTATING)) return true;
+	if ((state==TUIO_ACCELERATING) || (state==TUIO_DECELERATING) || (state==TUIO_ROTATING) || (state==TUIO_GEOMETRYCHANGED)) return true;
 	else return false;
 }
 

--- a/TUIO/TuioBlob.h
+++ b/TUIO/TuioBlob.h
@@ -20,6 +20,7 @@
 #define INCLUDED_TUIOBLOB_H
 
 #include "TuioContainer.h"
+#include <vector>
 
 namespace TUIO {
 	
@@ -31,6 +32,30 @@ namespace TUIO {
 	 */ 
 	class LIBDECL TuioBlob: public TuioContainer {
 		
+	public:
+		/**
+		 * The Point class represents point of the geometry (contour) of TuioBlob.
+		 * 
+		 * This is an EXTENSION, not included in TUIO 1.1 specification.
+		 */
+		struct Point
+		{
+			float x;
+			float y;
+
+			Point() :
+				x(0.0), y(0.0)
+			{}
+
+			Point(float _x, float _y) :
+				x(_x), y(_y)
+			{}
+
+			bool operator ==(const Point& _rhs) const {
+				return x == _rhs.x && y == _rhs.y;
+			}
+		};
+
 	protected:
 		/**
 		 * The individual blob ID number that is assigned to each TuioBlob.
@@ -60,7 +85,11 @@ namespace TUIO {
 		 * The rotation acceleration value.
 		 */ 
 		float rotation_accel;
-		
+		/**
+		 * the geometry (contour) of this blob.
+		 */
+		std::vector<Point> geometry;
+
 		float angleThreshold;
 		OneEuroFilter *angleFilter;
 		float sizeThreshold;
@@ -250,6 +279,22 @@ namespace TUIO {
 		 * @return	the rotation acceleration of this TuioBlob
 		 */
 		float getRotationAccel() const;
+
+		/**
+		 * Returns the geometry of this TuioBlob.
+		 * This is an EXTENSION, not included in TUIO 1.1 specification.
+		 * @return	the geometry of this TuioBlob
+		 */
+		const std::vector<Point>& getGeometry() const;
+
+		/**
+		 * Takes a TuioTime argument and assigns it along with the provided geometry.
+		 * This is an EXTENSION, not included in TUIO 1.1 specification.
+		 * 
+		 * @param	ttime	the TuioTime to assign
+		 * @param	g	the geometry to assign
+		 */
+		void updateGeometry(const TuioTime& ttime, const std::vector<Point>& g);
 
 		/**
 		 * Returns true of this TuioBlob is moving.

--- a/TUIO/TuioContainer.h
+++ b/TUIO/TuioContainer.h
@@ -30,6 +30,7 @@
 #define TUIO_ROTATING 4
 #define TUIO_STOPPED 5
 #define TUIO_REMOVED 6
+#define TUIO_GEOMETRYCHANGED 7
 
 #define MAX_PATH_SIZE 128
 

--- a/TUIO/TuioManager.cpp
+++ b/TUIO/TuioManager.cpp
@@ -256,7 +256,7 @@ void TuioManager::removeExternalTuioCursor(TuioCursor *tcur) {
 		(*listener)->removeTuioCursor(tcur);
 }
 
-TuioBlob* TuioManager::addTuioBlob(float x, float y, float a, float w, float h, float f) {
+TuioBlob* TuioManager::addTuioBlob(float x, float y, float a, float w, float h, float f, const std::vector<TuioBlob::Point>& g) {
 	sessionID++;
 	
 	int blobID = (int)blobList.size();
@@ -274,6 +274,8 @@ TuioBlob* TuioManager::addTuioBlob(float x, float y, float a, float w, float h, 
 	} else maxBlobID = blobID;	
 	
 	TuioBlob *tblb = new TuioBlob(currentFrameTime, sessionID, blobID, x, y, a, w, h, f);
+	tblb->updateGeometry(currentFrameTime, g);
+
 	blobList.push_back(tblb);
 	updateBlob = true;
 	
@@ -316,10 +318,12 @@ void TuioManager::addExternalTuioBlob(TuioBlob *tblb) {
 		std::cout << "add blb " << tblb->getBlobID() << " (" <<  tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY()  << " " << tblb->getAngle() << " " << tblb->getWidth()  << " " << tblb->getHeight() << " " << tblb->getArea() << std::endl;
 }
 
-void TuioManager::updateTuioBlob(TuioBlob *tblb,float x, float y, float a, float w, float h, float f) {
+void TuioManager::updateTuioBlob(TuioBlob *tblb,float x, float y, float a, float w, float h, float f, const std::vector<TuioBlob::Point>& g) {
 	if (tblb==NULL) return;
 	if (tblb->getTuioTime()==currentFrameTime) return;
 	tblb->update(currentFrameTime,x,y,a,w,h,f);
+	tblb->updateGeometry(currentFrameTime, g);
+
 	updateBlob = true;
 	
 	if (tblb->isMoving()) {	

--- a/TUIO/TuioManager.h
+++ b/TUIO/TuioManager.h
@@ -27,7 +27,10 @@
 
 #define OBJ_MESSAGE_SIZE 108	// setMessage + fseqMessage size
 #define CUR_MESSAGE_SIZE 88
-#define BLB_MESSAGE_SIZE 116
+
+#define BLB_SET_MESSAGE_SIZE 84
+#define BLB_FSEQ_MESSAGE_SIZE 32
+#define BLB_MESSAGE_SIZE (BLB_SET_MESSAGE_SIZE + BLB_FSEQ_MESSAGE_SIZE)
 
 namespace TUIO {
 	/**
@@ -187,9 +190,11 @@ namespace TUIO {
 		 * @param	width	the width to assign
 		 * @param	height	the height to assign
 		 * @param	area	the area to assign
+		 * @param	g	the geometry to assign (this is an EXTENSION, not included in TUIO 1.1 specification)
 		 * @return	reference to the created TuioBlob
 		 */
-		TuioBlob* addTuioBlob(float xp, float yp, float angle, float width, float height, float area);
+		TuioBlob* addTuioBlob(float xp, float yp, float angle, float width, float height, float area,
+			const std::vector<TuioBlob::Point>& g = std::vector<TuioBlob::Point>());
 		
 		/**
 		 * Updates the referenced TuioBlob based on the given arguments.
@@ -201,8 +206,10 @@ namespace TUIO {
 		 * @param	width	the width to assign
 		 * @param	height	the height to assign
 		 * @param	area	the area to assign
+		 * @param	g	the geometry to assign (this is an EXTENSION, not included in TUIO 1.1 specification)
 		 */
-		void updateTuioBlob(TuioBlob *tblb, float xp, float yp, float angle, float width, float height, float area);
+		void updateTuioBlob(TuioBlob *tblb, float xp, float yp, float angle, float width, float height, float area, 
+			const std::vector<TuioBlob::Point>& g = std::vector<TuioBlob::Point>());
 		
 		/**
 		 * Removes the referenced TuioBlob from the TuioServer's internal list of TuioBlobs

--- a/TUIO/UdpSender.cpp
+++ b/TUIO/UdpSender.cpp
@@ -79,6 +79,11 @@ bool UdpSender::isConnected() {
 	return true;
 }
 
+void UdpSender::setBufferSize(unsigned int size)
+{
+	buffer_size = size;
+}
+
 bool UdpSender::sendOscPacket (osc::OutboundPacketStream *bundle) {
 	if (socket==NULL) return false; 
 	if ( bundle->Size() > buffer_size ) return false;

--- a/TUIO/UdpSender.h
+++ b/TUIO/UdpSender.h
@@ -83,6 +83,11 @@ namespace TUIO {
 		 * @return true if the connection is alive
 		 */
 		 bool isConnected ();
+
+		 /**
+		  * This method sets the maximum bundle size in bytes
+		  */
+		 void setBufferSize(unsigned int size);
 		
 		 const char* tuio_type() { return "TUIO/UDP"; }
 		

--- a/TuioDump.cpp
+++ b/TuioDump.cpp
@@ -63,11 +63,39 @@ void TuioDump::removeTuioCursor(TuioCursor *tcur) {
 
 void TuioDump::addTuioBlob(TuioBlob *tblb) {
 	std::cout << "add blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/"<<  tblb->getTuioSourceID() << ") "<< tblb->getX() << " " << tblb->getY() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea() << std::endl;
+	
+	// the geometry is an EXTENSION, not included in TUIO 1.1 specification
+
+	if (!tblb->getGeometry().empty())
+	{
+		const std::vector<TuioBlob::Point>& geometry = tblb->getGeometry();
+
+		std::cout << "(";
+		for (int i = 0; i < geometry.size(); ++i)
+		{
+			std::cout << "(" << geometry[i].x << ", " << geometry[i].y << ")" << (i != geometry.size() - 1 ? ", " : "");
+		}
+		std::cout << ")" << std::endl;
+	}
 }
 
 void TuioDump::updateTuioBlob(TuioBlob *tblb) {
 	std::cout << "set blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/"<<  tblb->getTuioSourceID() << ") "<< tblb->getX() << " " << tblb->getY() << " " << tblb->getAngle() << " "<< tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea() 
 	<< " " << tblb->getMotionSpeed() << " " << tblb->getRotationSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << std::endl;
+	
+	// the geometry is an EXTENSION, not included in TUIO 1.1 specification
+
+	if (!tblb->getGeometry().empty())
+	{
+		const std::vector<TuioBlob::Point>& geometry = tblb->getGeometry();
+
+		std::cout << "(";
+		for (int i = 0; i < geometry.size(); ++i)
+		{
+			std::cout << "(" << geometry[i].x << ", " << geometry[i].y << ")" << (i != geometry.size() - 1 ? ", " : "");
+		}
+		std::cout << ")" << std::endl;
+	}
 }
 
 void TuioDump::removeTuioBlob(TuioBlob *tblb) {

--- a/oscpack/ip/win32/UdpSocket.cpp
+++ b/oscpack/ip/win32/UdpSocket.cpp
@@ -429,7 +429,7 @@ public:
 			timerQueue_.push_back( std::make_pair( currentTimeMs + i->initialDelayMs, *i ) );
 		std::sort( timerQueue_.begin(), timerQueue_.end(), CompareScheduledTimerCalls );
 
-		const int MAX_BUFFER_SIZE = 4098;
+		const int MAX_BUFFER_SIZE = 65507;
 		char *data = new char[ MAX_BUFFER_SIZE ];
 		IpEndpointName remoteEndpoint;
 

--- a/oscpack/osc/OscOutboundPacketStream.h
+++ b/oscpack/osc/OscOutboundPacketStream.h
@@ -87,6 +87,11 @@ public:
 
     const char *Data() const;
 
+	// sets new memory buffer as internal buffer.
+	// if new memory buffer capacity < current size then stream is cleared,
+	// else current buffer content persists (is copied to new memory buffer).
+	void Realloc( char* buffer, std::size_t capacity );
+
     // indicates that all messages have been closed with a matching EndMessage
     // and all bundles have been closed with a matching EndBundle
     bool IsReady() const;


### PR DESCRIPTION
This PR adds functionality to pass some optional geometry data with /2Dblb profile.

Geometry is optionally passed via TuioServer as OSC-blob at the end of /tuio/2Dblb SET message. This OSC-blob is a sequence of points, represented as (osc::float32, osc::float32) pairs. TuioClient would parse this geometry and call listeners updateTuioBlob(...) handlers if geometry changed.

I know that this feature is not included in TUIO 1.1 specification, but proposed in TUIO 2.0 (and not yet implemented). But it was very handy for me to implement this here because I have to receive this geometry in cross-language enviroment and we have no TUIO 2.0 implementation anythere from C++ now... 

Feel free to comment. 
Ivan
