### PR TITLE
Add 2.5D and 3D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ TuioDump
 TuioDemo
 
 SimpleSimulator
+windows/Release
+windows/Debug
+windows/.vs

--- a/SimpleSimulator.cpp
+++ b/SimpleSimulator.cpp
@@ -1,6 +1,7 @@
 /*
 	TUIO C++ Server Demo
-	Copyright (c)
+	Copyright (c) 2005-2016 Martin Kaltenbrunner <martin@tuio.org>
+	Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
 	This program is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by

--- a/SimpleSimulator.cpp
+++ b/SimpleSimulator.cpp
@@ -1,93 +1,440 @@
 /*
 	TUIO C++ Server Demo
-    Copyright (c) 2005-2016 Martin Kaltenbrunner <martin@tuio.org>
- 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
+	Copyright (c)
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
 #include "SimpleSimulator.h"
 void SimpleSimulator::drawFrame() {
 
-	if(!running) return;
+	if (!running) return;
 	glClear(GL_COLOR_BUFFER_BIT);
-	char id[3];
+	char id[20];
 
 	// draw the cursors
 	std::list<TuioCursor*> cursorList = tuioServer->getTuioCursors();
-	for (std::list<TuioCursor*>::iterator iter = cursorList.begin(); iter!=cursorList.end(); iter++) {
+	for (std::list<TuioCursor*>::iterator iter = cursorList.begin(); iter != cursorList.end(); iter++) {
 		TuioCursor *tcur = (*iter);
 		std::list<TuioPoint> path = tcur->getPath();
-		if (path.size()>0) {
+		if (path.size() > 0) {
 
 			TuioPoint last_point = path.front();
 			glBegin(GL_LINES);
 			glColor3f(0.0, 0.0, 1.0);
 
-			for (std::list<TuioPoint>::iterator point = path.begin(); point!=path.end(); point++) {
+			for (std::list<TuioPoint>::iterator point = path.begin(); point != path.end(); point++) {
 				glVertex3f(last_point.getScreenX(width), last_point.getScreenY(height), 0.0f);
 				glVertex3f(point->getScreenX(width), point->getScreenY(height), 0.0f);
-				last_point.update(point->getX(),point->getY());
+				last_point.update(point->getX(), point->getY());
 			}
 			glEnd();
 
 			// draw the finger tip
 			glColor3f(0.75, 0.75, 0.75);
-			std::list<TuioCursor*>::iterator joint = std::find( jointCursorList.begin(), jointCursorList.end(), tcur );
-			if( joint != jointCursorList.end() ) {
+			std::list<TuioCursor*>::iterator joint = std::find(jointCursorList.begin(), jointCursorList.end(), tcur);
+			if (joint != jointCursorList.end()) {
 				glColor3f(0.5, 0.5, 0.5);
 			}
 			glPushMatrix();
 			glTranslatef(last_point.getScreenX(width), last_point.getScreenY(height), 0.0f);
 			glBegin(GL_TRIANGLE_FAN);
-			for(double a = 0.0f; a <= 2*M_PI; a += 0.2f) {
-				glVertex2d(cos(a) * height/100.0f, sin(a) * height/100.0f);
+			for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+				glVertex2d(cos(a) * height / 100.0f, sin(a) * height / 100.0f);
 			}
 			glEnd();
 			glPopMatrix();
 
 			glColor3f(0.0, 0.0, 0.0);
-			glRasterPos2f(tcur->getScreenX(width),tcur->getScreenY(height));
-			sprintf(id,"%d",tcur->getCursorID());
+			glRasterPos2f(tcur->getScreenX(width), tcur->getScreenY(height));
+			sprintf(id, "2Dcur %d", tcur->getCursorID());
 			drawString(id);
 		}
 	}
 
+
+	// draw the objects
+	std::list<TuioObject*> objectList = tuioServer->getTuioObjects();
+	for (std::list<TuioObject*>::iterator iter = objectList.begin(); iter != objectList.end(); iter++) {
+		TuioObject *tuioObject = (*iter);
+		int pos_size = height / 20.0f;
+		int neg_size = -1 * pos_size;
+		float xpos = tuioObject->getScreenX(width);
+		float ypos = tuioObject->getScreenY(height);
+		float angle = tuioObject->getAngleDegrees();
+
+		glColor3f(0.75, 0.75, 0.75);
+		std::list<TuioObject*>::iterator joint = std::find(jointObjectList.begin(), jointObjectList.end(), tuioObject);
+		if (joint != jointObjectList.end()) {
+			glColor3f(0.5, 0.5, 0.5);
+		}
+
+
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(angle, 0.0, 0.0, 1.0);
+		glBegin(GL_QUADS);
+		glVertex2f(neg_size, neg_size);
+		glVertex2f(neg_size, pos_size);
+		glVertex2f(pos_size, pos_size);
+		glVertex2f(pos_size, neg_size);
+		glEnd();
+		glPopMatrix();
+
+		glColor3f(0.0, 0.0, 0.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "2Dobj %d", tuioObject->getSymbolID());
+		drawString(id);
+	}
+
+	// draw the blobs
+	std::list<TuioBlob*> blobList = tuioServer->getTuioBlobs();
+	for (std::list<TuioBlob*>::iterator iter = blobList.begin(); iter != blobList.end(); iter++) {
+		TuioBlob *tuioBlob = (*iter);
+		float blob_width = tuioBlob->getScreenWidth(width) / 2;
+		float blob_height = tuioBlob->getScreenHeight(height) / 2;
+		float xpos = tuioBlob->getScreenX(width);
+		float ypos = tuioBlob->getScreenY(height);
+		float angle = tuioBlob->getAngleDegrees();
+
+
+		glColor3f(0.75, 0.75, 0.75);
+		std::list<TuioBlob*>::iterator joint = std::find(jointBlobList.begin(), jointBlobList.end(), tuioBlob);
+		if (joint != jointBlobList.end()) {
+			glColor3f(0.5, 0.5, 0.5);
+		}
+
+
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(angle, 0.0, 0.0, 1.0);
+
+
+		glBegin(GL_TRIANGLE_FAN);
+		for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+			glVertex2d(cos(a) * blob_width, sin(a) * blob_height);
+		} glEnd();
+
+		glPopMatrix();
+
+		glColor3f(0.0, 0.0, 0.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "2Dblb %d", tuioBlob->getBlobID());
+		drawString(id);
+	}
+
+
+
+
+	// draw the 25Dcursors
+	std::list<TuioCursor25D*> cursor25DList = tuioServer->getTuioCursors25D();
+	for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++) {
+		TuioCursor25D *tcur = (*iter);
+		std::list<TuioPoint> path = tcur->getPath();
+		if (path.size() > 0) {
+
+			TuioPoint last_point = path.front();
+			glBegin(GL_LINES);
+			//glColor3f(0.0, 0.0, 1.0);
+
+			for (std::list<TuioPoint>::iterator point = path.begin(); point != path.end(); point++) {
+
+				glColor3f(1.0 - point->getZ(), point->getZ(), 0.0); // change color according to Z coordinates from red (0) to green (1)
+				glVertex3f(last_point.getScreenX(width), last_point.getScreenY(height), 0.0f);
+				glVertex3f(point->getScreenX(width), point->getScreenY(height), 0.0f);
+				last_point.update(point->getX(), point->getY());
+			}
+			glEnd();
+
+			// draw the finger tip
+			glColor3f(1.0 - last_point.getZ(), last_point.getZ(), 0.75);
+			std::list<TuioCursor25D*>::iterator joint = std::find(jointCursor25DList.begin(), jointCursor25DList.end(), tcur);
+			if (joint != jointCursor25DList.end()) {
+				glColor3f(1.0 - last_point.getZ(), last_point.getZ(), 0.5);
+			}
+			glPushMatrix();
+			glTranslatef(last_point.getScreenX(width), last_point.getScreenY(height), 0.0f);
+			glBegin(GL_TRIANGLE_FAN);
+			for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+				glVertex2d(cos(a) * height / 100.0f, sin(a) * height / 100.0f);
+			}
+			glEnd();
+			glPopMatrix();
+
+			glColor3f(0.0, 0.0, 0.0);
+			glRasterPos2f(tcur->getScreenX(width), tcur->getScreenY(height));
+			sprintf(id, "25Dcur %d", tcur->getCursorID());
+			drawString(id);
+		}
+	}
+
+
+	// draw the 25Dobjects
+	std::list<TuioObject25D*> object25DList = tuioServer->getTuioObjects25D();
+	for (std::list<TuioObject25D*>::iterator iter = object25DList.begin(); iter != object25DList.end(); iter++) {
+		TuioObject25D *tuioObject = (*iter);
+		int pos_size = height / 20.0f;
+		int neg_size = -1 * pos_size;
+		float xpos = tuioObject->getScreenX(width);
+		float ypos = tuioObject->getScreenY(height);
+		float angle = tuioObject->getAngleDegrees();
+
+		glColor3f(1.0 - tuioObject->getZ(), tuioObject->getZ(), 0.75);
+		std::list<TuioObject25D*>::iterator joint = std::find(jointObject25DList.begin(), jointObject25DList.end(), tuioObject);
+		if (joint != jointObject25DList.end()) {
+			glColor3f(1.0 - tuioObject->getZ(), tuioObject->getZ(), 0.5);
+		}
+
+
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(angle, 0.0, 0.0, 1.0);
+		glBegin(GL_QUADS);
+		glVertex2f(neg_size, neg_size);
+		glVertex2f(neg_size, pos_size);
+		glVertex2f(pos_size, pos_size);
+		glVertex2f(pos_size, neg_size);
+		glEnd();
+		glPopMatrix();
+
+		glColor3f(0.0, 0.0, 0.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "25Dobj %d", tuioObject->getSymbolID());
+		drawString(id);
+	}
+
+	// draw the 25Dblobs
+	std::list<TuioBlob25D*> blob25DList = tuioServer->getTuioBlobs25D();
+	for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++) {
+		TuioBlob25D *tuioBlob = (*iter);
+		float blob_width = tuioBlob->getSpaceWidth(width) / 2;
+		float blob_height = tuioBlob->getSpaceHeight(height) / 2;
+		float xpos = tuioBlob->getScreenX(width);
+		float ypos = tuioBlob->getScreenY(height);
+		float angle = tuioBlob->getAngleDegrees();
+
+
+		glColor3f(1.0 - tuioBlob->getZ(), tuioBlob->getZ(), 0.75);
+		std::list<TuioBlob25D*>::iterator joint = std::find(jointBlob25DList.begin(), jointBlob25DList.end(), tuioBlob);
+		if (joint != jointBlob25DList.end()) {
+			glColor3f(1.0 - tuioBlob->getZ(), tuioBlob->getZ(), 0.5);
+		}
+
+
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(angle, 0.0, 0.0, 1.0);
+
+
+		glBegin(GL_TRIANGLE_FAN);
+		for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+			glVertex2d(cos(a) * blob_width, sin(a) * blob_height);
+		} glEnd();
+
+		glPopMatrix();
+
+		glColor3f(0.0, 0.0, 0.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "25Dblb %d", tuioBlob->getBlobID());
+		drawString(id);
+	}
+
+
+
+
+
+	// draw the 3Dcursors
+	std::list<TuioCursor3D*> cursor3DList = tuioServer->getTuioCursors3D();
+	for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++) {
+		TuioCursor3D *tcur = (*iter);
+		std::list<TuioPoint> path = tcur->getPath();
+		if (path.size() > 0) {
+
+			TuioPoint last_point = path.front();
+			glBegin(GL_LINES);
+			//glColor3f(0.0, 0.0, 1.0);
+
+			for (std::list<TuioPoint>::iterator point = path.begin(); point != path.end(); point++) {
+
+				glColor3f(1.0 - point->getZ(), point->getZ(), 0.0); // change color according to Z coordinates from red (0) to green (1)
+				glVertex3f(last_point.getScreenX(width), last_point.getScreenY(height), 0.0f);
+				glVertex3f(point->getScreenX(width), point->getScreenY(height), 0.0f);
+				last_point.update(point->getX(), point->getY());
+			}
+			glEnd();
+
+			// draw the finger tip
+			glColor3f(1.0 - last_point.getZ(), last_point.getZ(), 0.75);
+			std::list<TuioCursor3D*>::iterator joint = std::find(jointCursor3DList.begin(), jointCursor3DList.end(), tcur);
+			if (joint != jointCursor3DList.end()) {
+				glColor3f(1.0 - last_point.getZ(), last_point.getZ(), 0.5);
+			}
+			glPushMatrix();
+			glTranslatef(last_point.getScreenX(width), last_point.getScreenY(height), 0.0f);
+			glBegin(GL_TRIANGLE_FAN);
+			for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+				glVertex2d(cos(a) * height / 100.0f, sin(a) * height / 100.0f);
+			}
+			glEnd();
+			glPopMatrix();
+
+			glColor3f(0.0, 0.0, 0.0);
+			glRasterPos2f(tcur->getScreenX(width), tcur->getScreenY(height));
+			sprintf(id, "3Dcur %d", tcur->getCursorID());
+			drawString(id);
+		}
+	}
+
+
+	// draw the 3Dobjects
+	std::list<TuioObject3D*> object3DList = tuioServer->getTuioObjects3D();
+	for (std::list<TuioObject3D*>::iterator iter = object3DList.begin(); iter != object3DList.end(); iter++) {
+		TuioObject3D *tuioObject = (*iter);
+		int pos_size = height / 20.0f;
+		int neg_size = -1 * pos_size;
+		float xpos = tuioObject->getScreenX(width);
+		float ypos = tuioObject->getScreenY(height);
+		float roll = tuioObject->getRollDegrees();
+		float pitch = tuioObject->getPitchDegrees();
+		float yaw = tuioObject->getYawDegrees();
+
+		glColor3f(1.0 - tuioObject->getZ(), tuioObject->getZ(), 0.75);
+		std::list<TuioObject3D*>::iterator joint = std::find(jointObject3DList.begin(), jointObject3DList.end(), tuioObject);
+		if (joint != jointObject3DList.end()) {
+			glColor3f(1.0 - tuioObject->getZ(), tuioObject->getZ(), 0.5);
+		}
+
+
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(roll, pitch, yaw, 1.0);
+		glBegin(GL_QUADS);
+		glVertex2f(neg_size, neg_size);
+		glVertex2f(neg_size, pos_size);
+		glVertex2f(pos_size, pos_size);
+		glVertex2f(pos_size, neg_size);
+		glEnd();
+		glPopMatrix();
+
+		glColor3f(0.0, 0.0, 0.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "3Dobj %d", tuioObject->getSymbolID());
+		drawString(id);
+	}
+
+	// draw the 3Dblobs
+	std::list<TuioBlob3D*> blob3DList = tuioServer->getTuioBlobs3D();
+	for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++) {
+		TuioBlob3D *tuioBlob = (*iter);
+		float blob_width = tuioBlob->getSpaceWidth(width) / 2;
+		float blob_height = tuioBlob->getSpaceHeight(height) / 2;
+		float xpos = tuioBlob->getScreenX(width);
+		float ypos = tuioBlob->getScreenY(height);
+		float roll = tuioBlob->getRollDegrees();
+		float pitch = tuioBlob->getPitchDegrees();
+		float yaw = tuioBlob->getYawDegrees();
+
+
+		glColor3f(1.0 - tuioBlob->getZ(), tuioBlob->getZ(), 0.75);
+		std::list<TuioBlob3D*>::iterator joint = std::find(jointBlob3DList.begin(), jointBlob3DList.end(), tuioBlob);
+		if (joint != jointBlob3DList.end()) {
+			glColor3f(1.0 - tuioBlob->getZ(), tuioBlob->getZ(), 0.5);
+		}
+
+
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(roll, pitch, yaw, 1.0);
+
+
+		glBegin(GL_TRIANGLE_FAN);
+		for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+			glVertex2d(cos(a) * blob_width, sin(a) * blob_height);
+		} glEnd();
+
+		glPopMatrix();
+
+		glColor3f(0.0, 0.0, 0.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "3Dblb %d", tuioBlob->getBlobID());
+		drawString(id);
+	}
+
+
+
+
+
+
+	glColor3f(0.0, 0.0, 1.0);
+	glRasterPos2f(width-150, 20);	
+	switch (mode)
+	{
+	case 0: sprintf(id, "Mode 2Dcur"); break;
+	case 1: sprintf(id, "Mode 2Dobj"); break;
+	case 2: sprintf(id, "Mode 2Dblb"); break;
+	case 3: sprintf(id, "Mode 25Dcur"); break;
+	case 4: sprintf(id, "Mode 25Dobj"); break;
+	case 5: sprintf(id, "Mode 25Dblb"); break;
+	case 6: sprintf(id, "Mode 3Dcur"); break;
+	case 7: sprintf(id, "Mode 3Dobj"); break;
+	case 8: sprintf(id, "Mode 3Dblb"); break;
+	}
+	drawString(id);
+
+	glRasterPos2f(width - 150, 45);
+	switch (control)
+	{
+	case 0: sprintf(id, "Control Z"); break;
+	case 1: sprintf(id, "Control roll/angle"); break;
+	case 2: sprintf(id, "Control pitch"); break;
+	case 3: sprintf(id, "Control yaw"); break;
+	case 4: sprintf(id, "Control width"); break;
+	case 5: sprintf(id, "Control height"); break;
+	case 6: sprintf(id, "Control depth"); break;
+	}
+	drawString(id);
+
 	if (help) {
 		glColor3f(0.0, 0.0, 1.0);
-		glRasterPos2f(10,20);
+		glRasterPos2f(10, 20);
 		drawString("h - toggle help display");
-		glRasterPos2f(10,35);
+		glRasterPos2f(10, 35);
 		if (verbose) drawString("v - disable verbose mode");
 		else drawString("v - enable verbose mode");
-		glRasterPos2f(10,50);
+		glRasterPos2f(10, 50);
 		drawString("r - reset session");
-		glRasterPos2f(10,65);
+		glRasterPos2f(10, 65);
 		if (tuioServer->fullUpdateEnabled()) drawString("f - disable full update");
 		else drawString("f - enable full update");
-		glRasterPos2f(10,80);
+		glRasterPos2f(10, 80);
 		if (tuioServer->periodicMessagesEnabled()) drawString("p - disable periodic messages");
 		else drawString("p - enable periodic messages");
-		glRasterPos2f(10,95);
+		glRasterPos2f(10, 95);
 		drawString("SHIFT click - create persistent cursor");
-		glRasterPos2f(10,110);
+		glRasterPos2f(10, 110);
 		drawString("CTRL click - add to cursor group");
-		glRasterPos2f(10,125);
+		glRasterPos2f(10, 125);
 		if (fullscreen) drawString("F1 - exit fullscreen mode");
 		else drawString("F1 - enter fullscreen mode");
-		glRasterPos2f(10,140);
+		glRasterPos2f(10, 140);
 		drawString("ESC - Quit");
+		glRasterPos2f(10, 155);
+		drawString("m - mode : 0=2Dcur/1=2Dobj/2=2Dblb/3=25Dcur/4=25Dobj/5=25Dblb/6=3Dcur/7=3Dobj/8=3Dblb");
+
+		glRasterPos2f(10, 170);
+		drawString("SCROLL - change the parameter defined by control");
+		glRasterPos2f(10, 185);
+		drawString("control (NumPad) : 0=Z/1=Roll/2=Pitch/3=Yaw/4=Width/5=Height/6=Depth");
 	}
 
 	SDL_GL_SwapWindow(window);
@@ -104,18 +451,19 @@ void SimpleSimulator::drawString(const char *str) {
 
 void SimpleSimulator::processEvents()
 {
-    SDL_Event event;
+	SDL_Event event;
 
-    while( SDL_PollEvent( &event ) ) {
-		
-        switch( event.type ) {
+	while (SDL_PollEvent(&event)) {
+
+		switch (event.type) {
 		case SDL_KEYDOWN:
-				if (event.key.repeat) continue;
-				else if( event.key.keysym.sym == SDLK_ESCAPE ){
+			if (event.key.repeat) continue;
+			else if (event.key.keysym.sym == SDLK_ESCAPE) {
 				running = false;
 				SDL_Quit();
-			} else if( event.key.keysym.sym == SDLK_F1 ){
-				if(fullscreen)
+			}
+			else if (event.key.keysym.sym == SDLK_F1) {
+				if (fullscreen)
 				{
 					width = window_width;
 					height = window_height;
@@ -129,7 +477,7 @@ void SimpleSimulator::processEvents()
 					SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
 					fullscreen = true;
 				}
-				
+
 				glClearColor(1.0f, 1.0f, 1.0f, 0.0f);
 				glViewport(0, 0, (GLint)width, (GLint)height);
 				glMatrixMode(GL_PROJECTION);
@@ -137,204 +485,1359 @@ void SimpleSimulator::processEvents()
 				gluOrtho2D(0, (GLfloat)width, (GLfloat)height, 0);
 				glMatrixMode(GL_MODELVIEW);
 				glLoadIdentity();
-			} else if( event.key.keysym.sym == SDLK_f ){
-				fullupdate=!tuioServer->fullUpdateEnabled();
+			}
+			else if (event.key.keysym.sym == SDLK_f) {
+				fullupdate = !tuioServer->fullUpdateEnabled();
 				if (fullupdate) tuioServer->enableFullUpdate();
 				else tuioServer->disableFullUpdate();
-			} else if( event.key.keysym.sym == SDLK_p ){
-				periodic=!tuioServer->periodicMessagesEnabled();
+			}
+			else if (event.key.keysym.sym == SDLK_p) {
+				periodic = !tuioServer->periodicMessagesEnabled();
 				if (periodic) tuioServer->enablePeriodicMessages();
 				else tuioServer->disablePeriodicMessages();
-			} else if( event.key.keysym.sym == SDLK_v ){
+			}
+			else if (event.key.keysym.sym == SDLK_v) {
 				verbose = !verbose;
 				tuioServer->setVerbose(verbose);
-			} else if( event.key.keysym.sym == SDLK_h ){
+			}
+			else if (event.key.keysym.sym == SDLK_h) {
 				help = !help;
-			} else if( event.key.keysym.sym == SDLK_r ){
+			}
+			else if (event.key.keysym.sym == SDLK_r) { 
 				tuioServer->resetTuioCursors();
 				stickyCursorList.clear();
 				jointCursorList.clear();
 				activeCursorList.clear();
+				tuioServer->resetTuioObjects();
+				stickyObjectList.clear();
+				jointObjectList.clear();
+				activeObjectList.clear();
+				tuioServer->resetTuioBlobs();
+				stickyBlobList.clear();
+				jointBlobList.clear();
+				activeBlobList.clear();
+
+				tuioServer->resetTuioCursors25D();
+				stickyCursor25DList.clear();
+				jointCursor25DList.clear();
+				activeCursor25DList.clear();
+				tuioServer->resetTuioObjects25D();
+				stickyObject25DList.clear();
+				jointObject25DList.clear();
+				activeObject25DList.clear();
+				tuioServer->resetTuioBlobs25D();
+				stickyBlob25DList.clear();
+				jointBlob25DList.clear();
+				activeBlob25DList.clear();
+
+				tuioServer->resetTuioCursors3D();
+				stickyCursor3DList.clear();
+				jointCursor3DList.clear();
+				activeCursor3DList.clear();
+				tuioServer->resetTuioObjects3D();
+				stickyObject3DList.clear();
+				jointObject3DList.clear();
+				activeObject3DList.clear();
+				tuioServer->resetTuioBlobs3D();
+				stickyBlob3DList.clear();
+				jointBlob3DList.clear();
+				activeBlob3DList.clear();
 			}
+			else if (event.key.keysym.sym == SDLK_0) {
+				mode = 0;
+			}
+			else if (event.key.keysym.sym == SDLK_1) {
+				mode = 1;
+			}
+			else if (event.key.keysym.sym == SDLK_2) {
+				mode = 2;
+			}
+			else if (event.key.keysym.sym == SDLK_3) {
+				mode = 3;
+			}
+			else if (event.key.keysym.sym == SDLK_4) {
+				mode = 4;
+			}
+			else if (event.key.keysym.sym == SDLK_5) {
+				mode = 5;
+			}
+			else if (event.key.keysym.sym == SDLK_6) {
+				mode = 6;
+			}
+			else if (event.key.keysym.sym == SDLK_7) {
+				mode = 7;
+			}
+			else if (event.key.keysym.sym == SDLK_8) {
+				mode = 8;
+			}
+			else if (event.key.keysym.sym == SDLK_KP_0) {
+				control = 0;
+			}
+			else if (event.key.keysym.sym == SDLK_KP_1) {
+				control = 1;
+			}
+			else if (event.key.keysym.sym == SDLK_KP_2) {
+				control = 2;
+			}
+			else if (event.key.keysym.sym == SDLK_KP_3) {
+				control = 3;
+			}
+			else if (event.key.keysym.sym == SDLK_KP_4) {
+				control = 4;
+			}
+			else if (event.key.keysym.sym == SDLK_KP_5) {
+				control = 5;
+			}
+			else if (event.key.keysym.sym == SDLK_KP_6) {
+				control = 6;
+			}
+
 			break;
 
 		case SDL_MOUSEMOTION:
-			if (event.button.button == SDL_BUTTON_LEFT) mouseDragged((float)event.button.x/width, (float)event.button.y/height);
+			if (event.button.button == SDL_BUTTON_LEFT) mouseDragged((float)event.button.x / width, (float)event.button.y / height);
 			break;
 		case SDL_MOUSEBUTTONDOWN:
-			if (event.button.button == SDL_BUTTON_LEFT) mousePressed((float)event.button.x/width, (float)event.button.y/height);
+			if (event.button.button == SDL_BUTTON_LEFT) mousePressed((float)event.button.x / width, (float)event.button.y / height);
 			break;
 		case SDL_MOUSEBUTTONUP:
-			if (event.button.button == SDL_BUTTON_LEFT) mouseReleased((float)event.button.x/width, (float)event.button.y/height);
+			if (event.button.button == SDL_BUTTON_LEFT) mouseReleased((float)event.button.x / width, (float)event.button.y / height);
 			break;
+
+		case SDL_MOUSEWHEEL:
+			applyExtraDimension(event.wheel.y);
+			break;
+
 		case SDL_QUIT:
 			running = false;
 			SDL_ShowCursor(true);
 			SDL_Quit();
 			break;
-        }
-    }
+		}
+	}
 }
+
+
 
 void SimpleSimulator::mousePressed(float x, float y) {
 	//printf("pressed %f %f\n",x,y);
 
-	TuioCursor *match = NULL;
-	float distance  = 0.01f;
-	for (std::list<TuioCursor*>::iterator iter = stickyCursorList.begin(); iter!=stickyCursorList.end(); iter++) {
-		TuioCursor *tcur = (*iter);
-		float test = tcur->getDistance(x,y);
-		if ((test < distance) && (test < 8.0f/width)) {
-			distance = test;
-			match = tcur;
-		}
-	}
-	
-	const Uint8 *keystate = SDL_GetKeyboardState(NULL);
-
-	if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT]))  {
-
-		if (match!=NULL) {
-			std::list<TuioCursor*>::iterator joint = std::find( jointCursorList.begin(), jointCursorList.end(), match );
-			if( joint != jointCursorList.end() ) {
-				jointCursorList.erase( joint );
+	switch (mode)
+	{
+		case(0):
+		{
+			TuioCursor *match = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioCursor*>::iterator iter = stickyCursorList.begin(); iter != stickyCursorList.end(); iter++) {
+				TuioCursor *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if ((test < distance) && (test < 8.0f / width)) {
+					distance = test;
+					match = tcur;
+				}
 			}
-			stickyCursorList.remove(match);
-			activeCursorList.remove(match);
-			tuioServer->removeTuioCursor(match);
-		} else {
-			TuioCursor *cursor = tuioServer->addTuioCursor(x,y);
-			stickyCursorList.push_back(cursor);
-			activeCursorList.push_back(cursor);
-		}
-	} else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
 
-		if (match!=NULL) {
-			std::list<TuioCursor*>::iterator joint = std::find( jointCursorList.begin(), jointCursorList.end(), match );
-			if( joint != jointCursorList.end() ) {
-				jointCursorList.remove( match );
-			} else jointCursorList.push_back(match);
+			const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+
+			if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT])) {
+
+				if (match != NULL) {
+					std::list<TuioCursor*>::iterator joint = std::find(jointCursorList.begin(), jointCursorList.end(), match);
+					if (joint != jointCursorList.end()) {
+						jointCursorList.erase(joint);
+					}
+					stickyCursorList.remove(match);
+					activeCursorList.remove(match);
+					tuioServer->removeTuioCursor(match);
+				}
+				else {
+					TuioCursor *cursor = tuioServer->addTuioCursor(x, y);
+					stickyCursorList.push_back(cursor);
+					activeCursorList.push_back(cursor);
+				}
+			}
+			else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
+
+				if (match != NULL) {
+					std::list<TuioCursor*>::iterator joint = std::find(jointCursorList.begin(), jointCursorList.end(), match);
+					if (joint != jointCursorList.end()) {
+						jointCursorList.remove(match);
+					}
+					else jointCursorList.push_back(match);
+				}
+			}
+			else {
+				if (match == NULL) {
+					TuioCursor *cursor = tuioServer->addTuioCursor(x, y);
+					activeCursorList.push_back(cursor);
+				}
+				else activeCursorList.push_back(match);
+			}
+			break;
+			}
+		case(1):
+		{
+			TuioObject *match = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioObject*>::iterator iter = stickyObjectList.begin(); iter != stickyObjectList.end(); iter++) {
+				TuioObject *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if ((test < distance) && (test < 8.0f / width)) {
+					distance = test;
+					match = tcur;
+				}
+			}
+
+			const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+
+			if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT])) {
+
+				if (match != NULL) {
+					std::list<TuioObject*>::iterator joint = std::find(jointObjectList.begin(), jointObjectList.end(), match);
+					if (joint != jointObjectList.end()) {
+						jointObjectList.erase(joint);
+					}
+					stickyObjectList.remove(match);
+					activeObjectList.remove(match);
+					tuioServer->removeTuioObject(match);
+				}
+				else {
+					TuioObject *cursor = tuioServer->addTuioObject(objectID, x, y, 0);
+					stickyObjectList.push_back(cursor);
+					activeObjectList.push_back(cursor); 
+					objectID++;
+				}
+			}
+			else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
+
+				if (match != NULL) {
+					std::list<TuioObject*>::iterator joint = std::find(jointObjectList.begin(), jointObjectList.end(), match);
+					if (joint != jointObjectList.end()) {
+						jointObjectList.remove(match);
+					}
+					else jointObjectList.push_back(match);
+				}
+			}
+			else {
+				if (match == NULL) {
+					TuioObject *cursor = tuioServer->addTuioObject(objectID, x, y, 0);
+					activeObjectList.push_back(cursor);
+					objectID++;
+				}
+				else activeObjectList.push_back(match);
+			}
+			break;
+			}
+		case(2):
+		{
+			TuioBlob *match = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioBlob*>::iterator iter = stickyBlobList.begin(); iter != stickyBlobList.end(); iter++) {
+				TuioBlob *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if ((test < distance) && (test < 8.0f / width)) {
+					distance = test;
+					match = tcur;
+				}
+			}
+
+			const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+
+			if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT])) {
+
+				if (match != NULL) {
+					std::list<TuioBlob*>::iterator joint = std::find(jointBlobList.begin(), jointBlobList.end(), match);
+					if (joint != jointBlobList.end()) {
+						jointBlobList.erase(joint);
+					}
+					stickyBlobList.remove(match);
+					activeBlobList.remove(match);
+					tuioServer->removeTuioBlob(match);
+				}
+				else {
+					TuioBlob *cursor = tuioServer->addTuioBlob( x, y,0, 0.1,0.1,0.1);
+					stickyBlobList.push_back(cursor);
+					activeBlobList.push_back(cursor);
+				}
+			}
+			else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
+
+				if (match != NULL) {
+					std::list<TuioBlob*>::iterator joint = std::find(jointBlobList.begin(), jointBlobList.end(), match);
+					if (joint != jointBlobList.end()) {
+						jointBlobList.remove(match);
+					}
+					else jointBlobList.push_back(match);
+				}
+			}
+			else {
+				if (match == NULL) {
+					TuioBlob *cursor = tuioServer->addTuioBlob(x, y,0, 0.1, 0.1, 0.1);
+					activeBlobList.push_back(cursor);
+				}
+				else activeBlobList.push_back(match);
+			}
+			break;
 		}
-	} else {
-		if (match==NULL) {
-			TuioCursor *cursor = tuioServer->addTuioCursor(x,y);
-			activeCursorList.push_back(cursor);
-		} else activeCursorList.push_back(match);
+		case(3):
+		{
+			TuioCursor25D *match = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioCursor25D*>::iterator iter = stickyCursor25DList.begin(); iter != stickyCursor25DList.end(); iter++) {
+				TuioCursor25D *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if ((test < distance) && (test < 8.0f / width)) {
+					distance = test;
+					match = tcur;
+				}
+			}
+
+			const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+
+			if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT])) {
+
+				if (match != NULL) {
+					std::list<TuioCursor25D*>::iterator joint = std::find(jointCursor25DList.begin(), jointCursor25DList.end(), match);
+					if (joint != jointCursor25DList.end()) {
+						jointCursor25DList.erase(joint);
+					}
+					stickyCursor25DList.remove(match);
+					activeCursor25DList.remove(match);
+					tuioServer->removeTuioCursor25D(match);
+				}
+				else {
+					TuioCursor25D *cursor = tuioServer->addTuioCursor25D(x, y,0);
+					stickyCursor25DList.push_back(cursor);
+					activeCursor25DList.push_back(cursor);
+				}
+			}
+			else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
+
+				if (match != NULL) {
+					std::list<TuioCursor25D*>::iterator joint = std::find(jointCursor25DList.begin(), jointCursor25DList.end(), match);
+					if (joint != jointCursor25DList.end()) {
+						jointCursor25DList.remove(match);
+					}
+					else jointCursor25DList.push_back(match);
+				}
+			}
+			else {
+				if (match == NULL) {
+					TuioCursor25D *cursor = tuioServer->addTuioCursor25D(x, y,0);
+					activeCursor25DList.push_back(cursor);
+				}
+				else activeCursor25DList.push_back(match);
+			}
+			break;
+		}
+		case(4):
+		{
+			TuioObject25D *match = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioObject25D*>::iterator iter = stickyObject25DList.begin(); iter != stickyObject25DList.end(); iter++) {
+				TuioObject25D *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if ((test < distance) && (test < 8.0f / width)) {
+					distance = test;
+					match = tcur;
+				}
+			}
+
+			const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+
+			if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT])) {
+
+				if (match != NULL) {
+					std::list<TuioObject25D*>::iterator joint = std::find(jointObject25DList.begin(), jointObject25DList.end(), match);
+					if (joint != jointObject25DList.end()) {
+						jointObject25DList.erase(joint);
+					}
+					stickyObject25DList.remove(match);
+					activeObject25DList.remove(match);
+					tuioServer->removeTuioObject25D(match);
+				}
+				else {
+					TuioObject25D *cursor = tuioServer->addTuioObject25D(objectID, x, y,0, 0);
+					stickyObject25DList.push_back(cursor);
+					activeObject25DList.push_back(cursor);
+					object25DID++;
+				}
+			}
+			else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
+
+				if (match != NULL) {
+					std::list<TuioObject25D*>::iterator joint = std::find(jointObject25DList.begin(), jointObject25DList.end(), match);
+					if (joint != jointObject25DList.end()) {
+						jointObject25DList.remove(match);
+					}
+					else jointObject25DList.push_back(match);
+				}
+			}
+			else {
+				if (match == NULL) {
+					TuioObject25D *cursor = tuioServer->addTuioObject25D(objectID, x, y, 0, 0);
+					activeObject25DList.push_back(cursor);
+					object25DID++;
+				}
+				else activeObject25DList.push_back(match);
+			}
+			break;
+		}
+		case(5):
+		{
+			TuioBlob25D *match = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioBlob25D*>::iterator iter = stickyBlob25DList.begin(); iter != stickyBlob25DList.end(); iter++) {
+				TuioBlob25D *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if ((test < distance) && (test < 8.0f / width)) {
+					distance = test;
+					match = tcur;
+				}
+			}
+
+			const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+
+			if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT])) {
+
+				if (match != NULL) {
+					std::list<TuioBlob25D*>::iterator joint = std::find(jointBlob25DList.begin(), jointBlob25DList.end(), match);
+					if (joint != jointBlob25DList.end()) {
+						jointBlob25DList.erase(joint);
+					}
+					stickyBlob25DList.remove(match);
+					activeBlob25DList.remove(match);
+					tuioServer->removeTuioBlob25D(match);
+				}
+				else {
+					TuioBlob25D *cursor = tuioServer->addTuioBlob25D(x, y,0, 0, 0.1, 0.1, 0.1);
+					stickyBlob25DList.push_back(cursor);
+					activeBlob25DList.push_back(cursor);
+				}
+			}
+			else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
+
+				if (match != NULL) {
+					std::list<TuioBlob25D*>::iterator joint = std::find(jointBlob25DList.begin(), jointBlob25DList.end(), match);
+					if (joint != jointBlob25DList.end()) {
+						jointBlob25DList.remove(match);
+					}
+					else jointBlob25DList.push_back(match);
+				}
+			}
+			else {
+				if (match == NULL) {
+					TuioBlob25D *cursor = tuioServer->addTuioBlob25D(x, y,0, 0, 0.1, 0.1, 0.1);
+					activeBlob25DList.push_back(cursor);
+				}
+				else activeBlob25DList.push_back(match);
+			}
+			break;
+		}
+		case(6):
+		{
+			TuioCursor3D *match = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioCursor3D*>::iterator iter = stickyCursor3DList.begin(); iter != stickyCursor3DList.end(); iter++) {
+				TuioCursor3D *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if ((test < distance) && (test < 8.0f / width)) {
+					distance = test;
+					match = tcur;
+				}
+			}
+
+			const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+
+			if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT])) {
+
+				if (match != NULL) {
+					std::list<TuioCursor3D*>::iterator joint = std::find(jointCursor3DList.begin(), jointCursor3DList.end(), match);
+					if (joint != jointCursor3DList.end()) {
+						jointCursor3DList.erase(joint);
+					}
+					stickyCursor3DList.remove(match);
+					activeCursor3DList.remove(match);
+					tuioServer->removeTuioCursor3D(match);
+				}
+				else {
+					TuioCursor3D *cursor = tuioServer->addTuioCursor3D(x, y, 0);
+					stickyCursor3DList.push_back(cursor);
+					activeCursor3DList.push_back(cursor);
+				}
+			}
+			else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
+
+				if (match != NULL) {
+					std::list<TuioCursor3D*>::iterator joint = std::find(jointCursor3DList.begin(), jointCursor3DList.end(), match);
+					if (joint != jointCursor3DList.end()) {
+						jointCursor3DList.remove(match);
+					}
+					else jointCursor3DList.push_back(match);
+				}
+			}
+			else {
+				if (match == NULL) {
+					TuioCursor3D *cursor = tuioServer->addTuioCursor3D(x, y, 0);
+					activeCursor3DList.push_back(cursor);
+				}
+				else activeCursor3DList.push_back(match);
+			}
+			break;
+		}
+		case(7):
+		{
+			TuioObject3D *match = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioObject3D*>::iterator iter = stickyObject3DList.begin(); iter != stickyObject3DList.end(); iter++) {
+				TuioObject3D *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if ((test < distance) && (test < 8.0f / width)) {
+					distance = test;
+					match = tcur;
+				}
+			}
+
+			const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+
+			if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT])) {
+
+				if (match != NULL) {
+					std::list<TuioObject3D*>::iterator joint = std::find(jointObject3DList.begin(), jointObject3DList.end(), match);
+					if (joint != jointObject3DList.end()) {
+						jointObject3DList.erase(joint);
+					}
+					stickyObject3DList.remove(match);
+					activeObject3DList.remove(match);
+					tuioServer->removeTuioObject3D(match);
+				}
+				else {
+					TuioObject3D *cursor = tuioServer->addTuioObject3D(objectID, x, y, 0, 0,0,0);
+					stickyObject3DList.push_back(cursor);
+					activeObject3DList.push_back(cursor);
+					object3DID++;
+				}
+			}
+			else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
+
+				if (match != NULL) {
+					std::list<TuioObject3D*>::iterator joint = std::find(jointObject3DList.begin(), jointObject3DList.end(), match);
+					if (joint != jointObject3DList.end()) {
+						jointObject3DList.remove(match);
+					}
+					else jointObject3DList.push_back(match);
+				}
+			}
+			else {
+				if (match == NULL) {
+					TuioObject3D *cursor = tuioServer->addTuioObject3D(objectID, x, y, 0, 0, 0, 0);
+					activeObject3DList.push_back(cursor);
+					object3DID++;
+				}
+				else activeObject3DList.push_back(match);
+			}
+			break;
+		}
+		case(8):
+		{
+			TuioBlob3D *match = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioBlob3D*>::iterator iter = stickyBlob3DList.begin(); iter != stickyBlob3DList.end(); iter++) {
+				TuioBlob3D *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if ((test < distance) && (test < 8.0f / width)) {
+					distance = test;
+					match = tcur;
+				}
+			}
+
+			const Uint8 *keystate = SDL_GetKeyboardState(NULL);
+
+			if ((keystate[SDL_SCANCODE_LSHIFT]) || (keystate[SDL_SCANCODE_RSHIFT])) {
+
+				if (match != NULL) {
+					std::list<TuioBlob3D*>::iterator joint = std::find(jointBlob3DList.begin(), jointBlob3DList.end(), match);
+					if (joint != jointBlob3DList.end()) {
+						jointBlob3DList.erase(joint);
+					}
+					stickyBlob3DList.remove(match);
+					activeBlob3DList.remove(match);
+					tuioServer->removeTuioBlob3D(match);
+				}
+				else {
+					TuioBlob3D *cursor = tuioServer->addTuioBlob3D(x, y, 0, 0,0,0, 0.1, 0.1,0.1, 0.1);
+					stickyBlob3DList.push_back(cursor);
+					activeBlob3DList.push_back(cursor);
+				}
+			}
+			else if ((keystate[SDL_SCANCODE_LCTRL]) || (keystate[SDL_SCANCODE_RCTRL])) {
+
+				if (match != NULL) {
+					std::list<TuioBlob3D*>::iterator joint = std::find(jointBlob3DList.begin(), jointBlob3DList.end(), match);
+					if (joint != jointBlob3DList.end()) {
+						jointBlob3DList.remove(match);
+					}
+					else jointBlob3DList.push_back(match);
+				}
+			}
+			else {
+				if (match == NULL) {
+					TuioBlob3D *cursor = tuioServer->addTuioBlob3D(x, y, 0, 0, 0, 0, 0.1, 0.1, 0.1, 0.1);
+					activeBlob3DList.push_back(cursor);
+				}
+				else activeBlob3DList.push_back(match);
+			}
+			break;
+		}
 	}
+
 }
 
 void SimpleSimulator::mouseDragged(float x, float y) {
 	//printf("dragged %f %f\n",x,y);
+	switch (mode)
+	{
+	case 0 :
+		{
+			TuioCursor *cursor = NULL;
+			float distance = width;
+			for (std::list<TuioCursor*>::iterator iter = activeCursorList.begin(); iter != activeCursorList.end(); iter++) {
+				TuioCursor *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if (test < distance) {
+					distance = test;
+					cursor = tcur;
+				}
+			}
 
-	TuioCursor *cursor = NULL;
-	float distance  = width;
-	for (std::list<TuioCursor*>::iterator iter = activeCursorList.begin(); iter!=activeCursorList.end(); iter++) {
-		TuioCursor *tcur = (*iter);
-		float test = tcur->getDistance(x,y);
-		if (test<distance) {
-			distance = test;
-			cursor = tcur;
+			if (cursor == NULL) return;
+			if (cursor->getTuioTime() == frameTime) return;
+
+			std::list<TuioCursor*>::iterator joint = std::find(jointCursorList.begin(), jointCursorList.end(), cursor);
+			if (joint != jointCursorList.end()) {
+				float dx = x - cursor->getX();
+				float dy = y - cursor->getY();
+				for (std::list<TuioCursor*>::iterator iter = jointCursorList.begin(); iter != jointCursorList.end(); iter++) {
+					TuioCursor *jointCursor = (*iter);
+					tuioServer->updateTuioCursor(jointCursor, jointCursor->getX() + dx, jointCursor->getY() + dy);
+				}
+			}
+			else tuioServer->updateTuioCursor(cursor, x, y);
 		}
+		break;
+	case 1:
+	{
+		TuioObject *cursor = NULL;
+		float distance = width;
+		for (std::list<TuioObject*>::iterator iter = activeObjectList.begin(); iter != activeObjectList.end(); iter++) {
+			TuioObject *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor == NULL) return;
+		if (cursor->getTuioTime() == frameTime) return;
+
+		std::list<TuioObject*>::iterator joint = std::find(jointObjectList.begin(), jointObjectList.end(), cursor);
+		if (joint != jointObjectList.end()) {
+			float dx = x - cursor->getX();
+			float dy = y - cursor->getY();
+			for (std::list<TuioObject*>::iterator iter = jointObjectList.begin(); iter != jointObjectList.end(); iter++) {
+				TuioObject *jointObject = (*iter);
+				tuioServer->updateTuioObject(jointObject, jointObject->getX() + dx, jointObject->getY() + dy, jointObject->getAngle());
+			}
+		}
+		else tuioServer->updateTuioObject(cursor, x, y, cursor->getAngle());
+	}
+	break;
+	case 2:
+	{
+		TuioBlob *cursor = NULL;
+		float distance = width;
+		for (std::list<TuioBlob*>::iterator iter = activeBlobList.begin(); iter != activeBlobList.end(); iter++) {
+			TuioBlob *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor == NULL) return;
+		if (cursor->getTuioTime() == frameTime) return;
+
+		std::list<TuioBlob*>::iterator joint = std::find(jointBlobList.begin(), jointBlobList.end(), cursor);
+		if (joint != jointBlobList.end()) {
+			float dx = x - cursor->getX();
+			float dy = y - cursor->getY();
+			for (std::list<TuioBlob*>::iterator iter = jointBlobList.begin(); iter != jointBlobList.end(); iter++) {
+				TuioBlob *jointBlob = (*iter);
+				tuioServer->updateTuioBlob(jointBlob, jointBlob->getX() + dx, jointBlob->getY() + dy, jointBlob->getAngle(), jointBlob->getWidth(), jointBlob->getHeight(), jointBlob->getArea());
+			}
+		}
+		else tuioServer->updateTuioBlob(cursor, x, y, cursor->getAngle(), cursor->getWidth(), cursor->getHeight(), cursor->getArea());
+	}
+	break;
+	case 3:
+	{
+		TuioCursor25D *cursor = NULL;
+		float distance = width;
+		for (std::list<TuioCursor25D*>::iterator iter = activeCursor25DList.begin(); iter != activeCursor25DList.end(); iter++) {
+			TuioCursor25D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor == NULL) return;
+		if (cursor->getTuioTime() == frameTime) return;
+
+		std::list<TuioCursor25D*>::iterator joint = std::find(jointCursor25DList.begin(), jointCursor25DList.end(), cursor);
+		if (joint != jointCursor25DList.end()) {
+			float dx = x - cursor->getX();
+			float dy = y - cursor->getY();
+			for (std::list<TuioCursor25D*>::iterator iter = jointCursor25DList.begin(); iter != jointCursor25DList.end(); iter++) {
+				TuioCursor25D *jointCursor = (*iter);
+				tuioServer->updateTuioCursor25D(jointCursor, jointCursor->getX() + dx, jointCursor->getY() + dy, cursor->getZ() );
+			}
+		}
+		else tuioServer->updateTuioCursor25D(cursor, x, y, cursor->getZ());
+	}
+	break;
+	case 4:
+	{
+		TuioObject25D *cursor = NULL;
+		float distance = width;
+		for (std::list<TuioObject25D*>::iterator iter = activeObject25DList.begin(); iter != activeObject25DList.end(); iter++) {
+			TuioObject25D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor == NULL) return;
+		if (cursor->getTuioTime() == frameTime) return;
+
+		std::list<TuioObject25D*>::iterator joint = std::find(jointObject25DList.begin(), jointObject25DList.end(), cursor);
+		if (joint != jointObject25DList.end()) {
+			float dx = x - cursor->getX();
+			float dy = y - cursor->getY();
+			for (std::list<TuioObject25D*>::iterator iter = jointObject25DList.begin(); iter != jointObject25DList.end(); iter++) {
+				TuioObject25D *jointObject = (*iter);
+				tuioServer->updateTuioObject25D(jointObject, jointObject->getX() + dx, jointObject->getY() + dy, jointObject->getZ(), jointObject->getAngle());
+			}
+		}
+		else tuioServer->updateTuioObject25D(cursor, x, y, cursor->getZ(), cursor->getAngle());
+	}
+	break;
+	case 5:
+	{
+		TuioBlob25D *cursor = NULL;
+		float distance = width;
+		for (std::list<TuioBlob25D*>::iterator iter = activeBlob25DList.begin(); iter != activeBlob25DList.end(); iter++) {
+			TuioBlob25D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor == NULL) return;
+		if (cursor->getTuioTime() == frameTime) return;
+
+		std::list<TuioBlob25D*>::iterator joint = std::find(jointBlob25DList.begin(), jointBlob25DList.end(), cursor);
+		if (joint != jointBlob25DList.end()) {
+			float dx = x - cursor->getX();
+			float dy = y - cursor->getY();
+			for (std::list<TuioBlob25D*>::iterator iter = jointBlob25DList.begin(); iter != jointBlob25DList.end(); iter++) {
+				TuioBlob25D *jointBlob = (*iter);
+				tuioServer->updateTuioBlob25D(jointBlob, jointBlob->getX() + dx, jointBlob->getY() + dy, jointBlob->getZ(), jointBlob->getAngle(), jointBlob->getWidth(), jointBlob->getHeight(), jointBlob->getArea());
+			}
+		}
+		else tuioServer->updateTuioBlob25D(cursor, x, y, cursor->getZ(), cursor->getAngle(), cursor->getWidth(), cursor->getHeight(), cursor->getArea());
+	}
+	break;
+	case 6:
+	{
+		TuioCursor3D *cursor = NULL;
+		float distance = width;
+		for (std::list<TuioCursor3D*>::iterator iter = activeCursor3DList.begin(); iter != activeCursor3DList.end(); iter++) {
+			TuioCursor3D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor == NULL) return;
+		if (cursor->getTuioTime() == frameTime) return;
+
+		std::list<TuioCursor3D*>::iterator joint = std::find(jointCursor3DList.begin(), jointCursor3DList.end(), cursor);
+		if (joint != jointCursor3DList.end()) {
+			float dx = x - cursor->getX();
+			float dy = y - cursor->getY();
+			for (std::list<TuioCursor3D*>::iterator iter = jointCursor3DList.begin(); iter != jointCursor3DList.end(); iter++) {
+				TuioCursor3D *jointCursor = (*iter);
+				tuioServer->updateTuioCursor3D(jointCursor, jointCursor->getX() + dx, jointCursor->getY() + dy, cursor->getZ());
+			}
+		}
+		else tuioServer->updateTuioCursor3D(cursor, x, y, cursor->getZ());
+	}
+	break;
+	case 7:
+	{
+		TuioObject3D *cursor = NULL;
+		float distance = width;
+		for (std::list<TuioObject3D*>::iterator iter = activeObject3DList.begin(); iter != activeObject3DList.end(); iter++) {
+			TuioObject3D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor == NULL) return;
+		if (cursor->getTuioTime() == frameTime) return;
+
+		std::list<TuioObject3D*>::iterator joint = std::find(jointObject3DList.begin(), jointObject3DList.end(), cursor);
+		if (joint != jointObject3DList.end()) {
+			float dx = x - cursor->getX();
+			float dy = y - cursor->getY();
+			for (std::list<TuioObject3D*>::iterator iter = jointObject3DList.begin(); iter != jointObject3DList.end(); iter++) {
+				TuioObject3D *jointObject = (*iter);
+				tuioServer->updateTuioObject3D(jointObject, jointObject->getX() + dx, jointObject->getY() + dy, jointObject->getZ(), jointObject->getRoll(), jointObject->getPitch(), jointObject->getYaw());
+			}
+		}
+		else tuioServer->updateTuioObject3D(cursor, x, y, cursor->getZ(), cursor->getRoll(), cursor->getPitch(), cursor->getYaw());
+	}
+	break;
+	case 8:
+	{
+		TuioBlob3D *cursor = NULL;
+		float distance = width;
+		for (std::list<TuioBlob3D*>::iterator iter = activeBlob3DList.begin(); iter != activeBlob3DList.end(); iter++) {
+			TuioBlob3D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor == NULL) return;
+		if (cursor->getTuioTime() == frameTime) return;
+
+		std::list<TuioBlob3D*>::iterator joint = std::find(jointBlob3DList.begin(), jointBlob3DList.end(), cursor);
+		if (joint != jointBlob3DList.end()) {
+			float dx = x - cursor->getX();
+			float dy = y - cursor->getY();
+			for (std::list<TuioBlob3D*>::iterator iter = jointBlob3DList.begin(); iter != jointBlob3DList.end(); iter++) {
+				TuioBlob3D *jointBlob = (*iter);
+				tuioServer->updateTuioBlob3D(jointBlob, jointBlob->getX() + dx, jointBlob->getY() + dy, jointBlob->getZ(), jointBlob->getRoll(), jointBlob->getPitch(), jointBlob->getYaw(), jointBlob->getWidth(), jointBlob->getHeight(), jointBlob->getDepth(), jointBlob->getVolume() );
+			}
+		}
+		else tuioServer->updateTuioBlob3D(cursor, x, y, cursor->getZ(), cursor->getRoll(), cursor->getPitch(), cursor->getYaw(), cursor->getWidth(), cursor->getHeight(), cursor->getDepth(), cursor->getVolume());
+	}
+	break;
 	}
 
-	if (cursor==NULL) return;
-	if (cursor->getTuioTime()==frameTime) return;
-
-	std::list<TuioCursor*>::iterator joint = std::find( jointCursorList.begin(), jointCursorList.end(), cursor );
-	if( joint != jointCursorList.end() ) {
-		float dx = x-cursor->getX();
-		float dy = y-cursor->getY();
-		for (std::list<TuioCursor*>::iterator iter = jointCursorList.begin(); iter!=jointCursorList.end(); iter++) {
-			TuioCursor *jointCursor = (*iter);
-			 tuioServer->updateTuioCursor(jointCursor,jointCursor->getX()+dx,jointCursor->getY()+dy);
-		}
-	} else tuioServer->updateTuioCursor(cursor,x,y);
 }
 
 void SimpleSimulator::mouseReleased(float x, float y) {
 	//printf("released %f %f\n",x,y);
 
-	TuioCursor *cursor = NULL;
-	float distance  = 0.01f;
-	for (std::list<TuioCursor*>::iterator iter = stickyCursorList.begin(); iter!=stickyCursorList.end(); iter++) {
-		TuioCursor *tcur = (*iter);
-		float test = tcur->getDistance(x,y);
-		if (test<distance) {
-			distance = test;
-			cursor = tcur;
+	switch (mode)
+	{
+	case 0 :
+		{
+			TuioCursor *cursor = NULL;
+			float distance = 0.01f;
+			for (std::list<TuioCursor*>::iterator iter = stickyCursorList.begin(); iter != stickyCursorList.end(); iter++) {
+				TuioCursor *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if (test < distance) {
+					distance = test;
+					cursor = tcur;
+				}
+			}
+
+			if (cursor != NULL) {
+				activeCursorList.remove(cursor);
+				return;
+			}
+
+			distance = 0.01f;
+			for (std::list<TuioCursor*>::iterator iter = activeCursorList.begin(); iter != activeCursorList.end(); iter++) {
+				TuioCursor *tcur = (*iter);
+				float test = tcur->getDistance(x, y);
+				if (test < distance) {
+					distance = test;
+					cursor = tcur;
+				}
+			}
+
+			if (cursor != NULL) {
+				activeCursorList.remove(cursor);
+				tuioServer->removeTuioCursor(cursor);
+			}
+		}
+		break;
+	case 1: 
+	{
+		TuioObject *cursor = NULL;
+		float distance = 0.01f;
+		for (std::list<TuioObject*>::iterator iter = stickyObjectList.begin(); iter != stickyObjectList.end(); iter++) {
+			TuioObject *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeObjectList.remove(cursor);
+			return;
+		}
+
+		distance = 0.01f;
+		for (std::list<TuioObject*>::iterator iter = activeObjectList.begin(); iter != activeObjectList.end(); iter++) {
+			TuioObject *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeObjectList.remove(cursor);
+			tuioServer->removeTuioObject(cursor);
 		}
 	}
+	break;
+	case 2:
+	{
+		TuioBlob *cursor = NULL;
+		float distance = 0.01f;
+		for (std::list<TuioBlob*>::iterator iter = stickyBlobList.begin(); iter != stickyBlobList.end(); iter++) {
+			TuioBlob *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
 
-	if (cursor!=NULL) {
-		activeCursorList.remove(cursor);
-		return;
-	}
+		if (cursor != NULL) {
+			activeBlobList.remove(cursor);
+			return;
+		}
 
-	distance = 0.01f;
-	for (std::list<TuioCursor*>::iterator iter = activeCursorList.begin(); iter!=activeCursorList.end(); iter++) {
-		TuioCursor *tcur = (*iter);
-		float test = tcur->getDistance(x,y);
-		if (test<distance) {
-			distance = test;
-			cursor = tcur;
+		distance = 0.01f;
+		for (std::list<TuioBlob*>::iterator iter = activeBlobList.begin(); iter != activeBlobList.end(); iter++) {
+			TuioBlob *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeBlobList.remove(cursor);
+			tuioServer->removeTuioBlob(cursor);
 		}
 	}
+	break;
+	case 3:
+	{
+		TuioCursor25D *cursor = NULL;
+		float distance = 0.01f;
+		for (std::list<TuioCursor25D*>::iterator iter = stickyCursor25DList.begin(); iter != stickyCursor25DList.end(); iter++) {
+			TuioCursor25D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
 
-	if (cursor!=NULL) {
-		activeCursorList.remove(cursor);
-		tuioServer->removeTuioCursor(cursor);
+		if (cursor != NULL) {
+			activeCursor25DList.remove(cursor);
+			return;
+		}
+
+		distance = 0.01f;
+		for (std::list<TuioCursor25D*>::iterator iter = activeCursor25DList.begin(); iter != activeCursor25DList.end(); iter++) {
+			TuioCursor25D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeCursor25DList.remove(cursor);
+			tuioServer->removeTuioCursor25D(cursor);
+		}
 	}
+	break;
+	case 4:
+	{
+		TuioObject25D *cursor = NULL;
+		float distance = 0.01f;
+		for (std::list<TuioObject25D*>::iterator iter = stickyObject25DList.begin(); iter != stickyObject25DList.end(); iter++) {
+			TuioObject25D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeObject25DList.remove(cursor);
+			return;
+		}
+
+		distance = 0.01f;
+		for (std::list<TuioObject25D*>::iterator iter = activeObject25DList.begin(); iter != activeObject25DList.end(); iter++) {
+			TuioObject25D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeObject25DList.remove(cursor);
+			tuioServer->removeTuioObject25D(cursor);
+		}
+	}
+	break;
+	case 5:
+	{
+		TuioBlob25D *cursor = NULL;
+		float distance = 0.01f;
+		for (std::list<TuioBlob25D*>::iterator iter = stickyBlob25DList.begin(); iter != stickyBlob25DList.end(); iter++) {
+			TuioBlob25D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeBlob25DList.remove(cursor);
+			return;
+		}
+
+		distance = 0.01f;
+		for (std::list<TuioBlob25D*>::iterator iter = activeBlob25DList.begin(); iter != activeBlob25DList.end(); iter++) {
+			TuioBlob25D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeBlob25DList.remove(cursor);
+			tuioServer->removeTuioBlob25D(cursor);
+		}
+	}
+	break;
+	case 6:
+	{
+		TuioCursor3D *cursor = NULL;
+		float distance = 0.01f;
+		for (std::list<TuioCursor3D*>::iterator iter = stickyCursor3DList.begin(); iter != stickyCursor3DList.end(); iter++) {
+			TuioCursor3D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeCursor3DList.remove(cursor);
+			return;
+		}
+
+		distance = 0.01f;
+		for (std::list<TuioCursor3D*>::iterator iter = activeCursor3DList.begin(); iter != activeCursor3DList.end(); iter++) {
+			TuioCursor3D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeCursor3DList.remove(cursor);
+			tuioServer->removeTuioCursor3D(cursor);
+		}
+	}
+	break;
+	case 7:
+	{
+		TuioObject3D *cursor = NULL;
+		float distance = 0.01f;
+		for (std::list<TuioObject3D*>::iterator iter = stickyObject3DList.begin(); iter != stickyObject3DList.end(); iter++) {
+			TuioObject3D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeObject3DList.remove(cursor);
+			return;
+		}
+
+		distance = 0.01f;
+		for (std::list<TuioObject3D*>::iterator iter = activeObject3DList.begin(); iter != activeObject3DList.end(); iter++) {
+			TuioObject3D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeObject3DList.remove(cursor);
+			tuioServer->removeTuioObject3D(cursor);
+		}
+	}
+	break;
+	case 8:
+	{
+		TuioBlob3D *cursor = NULL;
+		float distance = 0.01f;
+		for (std::list<TuioBlob3D*>::iterator iter = stickyBlob3DList.begin(); iter != stickyBlob3DList.end(); iter++) {
+			TuioBlob3D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeBlob3DList.remove(cursor);
+			return;
+		}
+
+		distance = 0.01f;
+		for (std::list<TuioBlob3D*>::iterator iter = activeBlob3DList.begin(); iter != activeBlob3DList.end(); iter++) {
+			TuioBlob3D *tcur = (*iter);
+			float test = tcur->getDistance(x, y);
+			if (test < distance) {
+				distance = test;
+				cursor = tcur;
+			}
+		}
+
+		if (cursor != NULL) {
+			activeBlob3DList.remove(cursor);
+			tuioServer->removeTuioBlob3D(cursor);
+		}
+	}
+	break;
+	}
+
+
+
 }
 
+void SimpleSimulator::applyExtraDimension(float scroll) {
+	//printf("scroll %f %f\n",x,y);
+	//if (verbose) printf("Scroll %f\n", scroll); // 1 ou -1
+
+	float diffZ = 0, diffRoll = 0, diffPitch = 0, diffYaw = 0, diffWidth = 0, diffHeight = 0, diffDepth = 0;
+	switch (control)
+	{
+	case 0: diffZ += (scroll / 100.0f);
+		break;
+	case 1: diffRoll += scroll;
+		diffRoll = diffRoll * 3.14159 / 180.0;
+		break;
+	case 2: diffPitch += scroll;
+		diffPitch = diffPitch * 3.14159 / 180.0;
+		break;
+	case 3: diffYaw += scroll;
+		diffYaw = diffYaw * 3.14159 / 180.0;
+		break;
+	case 4: diffWidth += (scroll / 100.0f);
+		break;
+	case 5: diffHeight += (scroll / 100.0f);
+		break;
+	case 6: diffDepth += (scroll / 100.0f);
+		break;
+	}
+
+
+
+
+	switch (mode)
+	{
+	case 0:
+		{
+		printf("Nb sticky cursor : %d\n", stickyCursorList.size());
+		printf("Nb joint cursor : %d\n", jointCursorList.size());
+		printf("Nb active cursor : %d\n", activeCursorList.size());
+
+		}
+	break;
+	case 1:
+	{
+
+		for (std::list<TuioObject*>::iterator iter = jointObjectList.begin(); iter != jointObjectList.end(); iter++) {
+			TuioObject *jointObject = (*iter);
+			tuioServer->updateTuioObject(jointObject, jointObject->getX(), jointObject->getY(), jointObject->getAngle()+diffRoll);
+		}
+	}
+	break;
+	case 2:
+	{
+
+		for (std::list<TuioBlob*>::iterator iter = jointBlobList.begin(); iter != jointBlobList.end(); iter++) {
+			TuioBlob *jointBlob = (*iter);
+			tuioServer->updateTuioBlob(jointBlob, jointBlob->getX(), jointBlob->getY(), jointBlob->getAngle() + diffRoll, jointBlob->getWidth() + diffWidth, jointBlob->getHeight() + diffHeight, jointBlob->getArea());
+		}
+	}
+	break;
+	case 3:
+	{
+		for (std::list<TuioCursor25D*>::iterator iter = jointCursor25DList.begin(); iter != jointCursor25DList.end(); iter++) {
+			TuioCursor25D *jointObject = (*iter);
+			tuioServer->updateTuioCursor25D(jointObject, jointObject->getX(), jointObject->getY(), jointObject->getZ() + diffZ);
+		}
+
+	}
+	break;
+	case 4:
+	{
+
+		for (std::list<TuioObject25D*>::iterator iter = jointObject25DList.begin(); iter != jointObject25DList.end(); iter++) {
+			TuioObject25D *jointObject = (*iter);
+			tuioServer->updateTuioObject25D(jointObject, jointObject->getX(), jointObject->getY(), jointObject->getZ() + diffZ, jointObject->getAngle() + diffRoll);
+		}
+	}
+	break;
+	case 5:
+	{
+
+		for (std::list<TuioBlob25D*>::iterator iter = jointBlob25DList.begin(); iter != jointBlob25DList.end(); iter++) {
+			TuioBlob25D *jointBlob = (*iter);
+			tuioServer->updateTuioBlob25D(jointBlob, jointBlob->getX(), jointBlob->getY(), jointBlob->getZ() + diffZ, jointBlob->getAngle() + diffRoll, jointBlob->getWidth() + diffWidth, jointBlob->getHeight() + diffHeight, jointBlob->getArea());
+		}
+	}
+	break;
+	case 6:
+	{
+		for (std::list<TuioCursor3D*>::iterator iter = jointCursor3DList.begin(); iter != jointCursor3DList.end(); iter++) {
+			TuioCursor3D *jointObject = (*iter);
+			tuioServer->updateTuioCursor3D(jointObject, jointObject->getX(), jointObject->getY(), jointObject->getZ() + diffZ);
+		}
+
+	}
+	break;
+	case 7:
+	{
+
+		for (std::list<TuioObject3D*>::iterator iter = jointObject3DList.begin(); iter != jointObject3DList.end(); iter++) {
+			TuioObject3D *jointObject = (*iter);
+			tuioServer->updateTuioObject3D(jointObject, jointObject->getX(), jointObject->getY(), jointObject->getZ() + diffZ, jointObject->getRoll() + diffRoll, jointObject->getPitch() + diffPitch, jointObject->getYaw() + diffYaw);
+		}
+	}
+	break;
+	case 8:
+	{
+
+		for (std::list<TuioBlob3D*>::iterator iter = jointBlob3DList.begin(); iter != jointBlob3DList.end(); iter++) {
+			TuioBlob3D *jointBlob = (*iter);
+			tuioServer->updateTuioBlob3D(jointBlob, jointBlob->getX(), jointBlob->getY(), jointBlob->getZ() + diffZ, jointBlob->getRoll() + diffRoll, jointBlob->getPitch() + diffPitch, jointBlob->getYaw() + diffYaw, jointBlob->getWidth() + diffWidth, jointBlob->getHeight() + diffHeight, jointBlob->getDepth() + diffDepth, jointBlob->getVolume());
+		}
+	}
+	break;
+	}
+
+
+
+}
+
+
+
+
 SimpleSimulator::SimpleSimulator(TuioServer *server)
-	: verbose		(false)
-	, fullupdate	(false)
-	, periodic		(false)
-	, fullscreen	(false)
-	, help			(false)
-	, screen_width	(1024)
-	, screen_height	(768)
-	, window_width	(640)
-	, window_height	(480)
+	: verbose(false)
+	, fullupdate(false)
+	, periodic(false)
+	, fullscreen(false)
+	, help(false)
+	, screen_width(1024)
+	, screen_height(768)
+	, window_width(640)
+	, window_height(480)
 {
-	if ( SDL_Init(SDL_INIT_VIDEO) < 0 ) {
-		std::cerr << "SDL could not be initialized: " <<  SDL_GetError() << std::endl;
+	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+		std::cerr << "SDL could not be initialized: " << SDL_GetError() << std::endl;
 		SDL_Quit();
 		exit(1);
 	}
-    
-    TuioTime::initSession();
-    frameTime = TuioTime::getSessionTime();
-    
-    tuioServer = server;
-    tuioServer->setSourceName("SimpleSimulator");
-    tuioServer->enableObjectProfile(false);
-    tuioServer->enableBlobProfile(false);
+
+	TuioTime::initSession();
+	frameTime = TuioTime::getSessionTime();
+
+	tuioServer = server;
+	tuioServer->setSourceName("SimpleSimulator");
 
 	initWindow();
-	SDL_SetWindowTitle(window,"SimpleSimulator");
+	SDL_SetWindowTitle(window, "SimpleSimulator");
 }
 
 void SimpleSimulator::initWindow() {
 
-	SDL_DisplayMode mode;
-	SDL_GetCurrentDisplayMode(0, &mode);
-	screen_width = mode.w;
-	screen_height= mode.h;
-	
+	SDL_DisplayMode displaymode;
+	SDL_GetCurrentDisplayMode(0, &displaymode);
+	screen_width = displaymode.w;
+	screen_height = displaymode.h;
+
 	int videoFlags = SDL_WINDOW_OPENGL;
-	if( fullscreen ) {
+	if (fullscreen) {
 		videoFlags |= SDL_WINDOW_FULLSCREEN;
 		width = screen_width;
 		height = screen_height;
-	} else {
-		width = window_width;
+	}
+	else {
+		width = window_width; 
 		height = window_height;
 	}
-	
+
 	SDL_CreateWindowAndRenderer(width, height, videoFlags, &window, &renderer);
-	
-	if ( window == NULL ) {
+
+	if (window == NULL) {
 		std::cerr << "Could not open window: " << SDL_GetError() << std::endl;
 		SDL_Quit();
 	}
@@ -349,66 +1852,77 @@ void SimpleSimulator::initWindow() {
 	glViewport(0, 0, width, height);
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
-	gluOrtho2D(0, (float)width,  (float)height, 0);
+	gluOrtho2D(0, (float)width, (float)height, 0);
 	glMatrixMode(GL_MODELVIEW);
 	glLoadIdentity();
 }
 
 void SimpleSimulator::run() {
-	running=true;
+	running = true;
 	while (running) {
 		frameTime = TuioTime::getSessionTime();
 		tuioServer->initFrame(frameTime);
 		processEvents();
 		tuioServer->stopUntouchedMovingCursors();
+		tuioServer->stopUntouchedMovingObjects();
+		tuioServer->stopUntouchedMovingBlobs();
+		tuioServer->stopUntouchedMovingCursors25D();
+		tuioServer->stopUntouchedMovingObjects25D();
+		tuioServer->stopUntouchedMovingBlobs25D();
+		tuioServer->stopUntouchedMovingCursors3D();
+		tuioServer->stopUntouchedMovingObjects3D();
+		tuioServer->stopUntouchedMovingBlobs3D();
 		tuioServer->commitFrame();
 		drawFrame();
 
 		// simulate 50Hz compensating the previous processing time
 		int delay = 20 - (TuioTime::getSessionTime().getTotalMilliseconds() - frameTime.getTotalMilliseconds());
-		if (delay>0) SDL_Delay(delay);
+		if (delay > 0) SDL_Delay(delay);
 	}
 }
 
 int main(int argc, char* argv[])
 {
-/*	if (( argc != 1) && ( argc != 3)) {
-        	std::cout << "usage: SimpleSimulator [host] [port]\n";
-        	return 0;
-	}*/
+	/*	if (( argc != 1) && ( argc != 3)) {
+				std::cout << "usage: SimpleSimulator [host] [port]\n";
+				return 0;
+		}*/
 
 #ifndef __MACOSX__
-	glutInit(&argc,argv);
+	glutInit(&argc, argv);
 #else
-    if ((argc>1) && ((std::string(argv[1]).find("-NSDocumentRevisionsDebugMode")==0 ) || (std::string(argv[1]).find("-psn_")==0))) argc = 1;
+	if ((argc > 1) && ((std::string(argv[1]).find("-NSDocumentRevisionsDebugMode") == 0) || (std::string(argv[1]).find("-psn_") == 0))) argc = 1;
 #endif
 
 	TuioServer *server = NULL;
-	if( argc == 3 ) {
-		server = new TuioServer(argv[1],atoi(argv[2]));
-	} else server = new TuioServer(); // default is UDP port 3333 on localhost
+	if (argc == 3) {
+		server = new TuioServer(argv[1], atoi(argv[2]));
+	}
+	else server = new TuioServer(); // default is UDP port 3333 on localhost
 
-	// add an additional TUIO/TCP sender
+ // add an additional TUIO/TCP sender
 	OscSender *tcp_sender = NULL;
-	if( argc == 2 ) {
+	if (argc == 2) {
 		try { tcp_sender = new TcpSender(atoi(argv[1])); }
 		catch (std::exception e) { tcp_sender = NULL; }
-	} else if ( argc == 3 ) {
-		try { tcp_sender = new TcpSender(argv[1],atoi(argv[2])); }
+	}
+	else if (argc == 3) {
+		try { tcp_sender = new TcpSender(argv[1], atoi(argv[2])); }
 		catch (std::exception e) { tcp_sender = NULL; }
-	} else {
+	}
+	else {
 		try { tcp_sender = new TcpSender(3333); }
 		catch (std::exception e) { tcp_sender = NULL; }
 	}
 	if (tcp_sender) server->addOscSender(tcp_sender);
 
-	
+
 	// add an additional TUIO/WEB sender
 	OscSender *web_sender = NULL;
 	try { web_sender = new WebSockSender(8080); }
 	catch (std::exception e) { web_sender = NULL; }
 	if (web_sender) server->addOscSender(web_sender);
-	
+
 	// add an additional TUIO/FLC sender
 	OscSender *flash_sender = NULL;
 	try { flash_sender = new FlashSender(); }
@@ -422,5 +1936,3 @@ int main(int argc, char* argv[])
 	delete server;
 	return 0;
 }
-
-

--- a/SimpleSimulator.cpp
+++ b/SimpleSimulator.cpp
@@ -1800,6 +1800,11 @@ SimpleSimulator::SimpleSimulator(TuioServer *server)
 	, screen_height(768)
 	, window_width(640)
 	, window_height(480)
+	, mode(0)
+	, control(0)
+	, objectID(0)
+	, object25DID(0)
+	, object3DID(0)
 {
 	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
 		std::cerr << "SDL could not be initialized: " << SDL_GetError() << std::endl;

--- a/SimpleSimulator.h
+++ b/SimpleSimulator.h
@@ -52,14 +52,14 @@ public:
 	
 	void run();
 	TuioServer *tuioServer;
-	int mode = 0; // 0: 2Dcur; 1: 2Dobj; 2: 2Dblb; 3: 25Dcur; 4: 25Dobj; 5: 25Dblb; 6: 3Dcur; 7: 3Dobj; 8: 3Dblb
-	int control = 0;// 0: z; 1: roll/angle; 2: pitch; 3: yaw; 4: width; 5: height; 6: depth
+	int mode; // 0: 2Dcur; 1: 2Dobj; 2: 2Dblb; 3: 25Dcur; 4: 25Dobj; 5: 25Dblb; 6: 3Dcur; 7: 3Dobj; 8: 3Dblb
+	int control;// 0: z; 1: roll/angle; 2: pitch; 3: yaw; 4: width; 5: height; 6: depth
 
 	std::list<TuioCursor*> stickyCursorList;
 	std::list<TuioCursor*> jointCursorList;
 	std::list<TuioCursor*> activeCursorList;
 
-	int objectID = 0;
+	int objectID;
 	std::list<TuioObject*> stickyObjectList;
 	std::list<TuioObject*> jointObjectList;
 	std::list<TuioObject*> activeObjectList;
@@ -73,7 +73,7 @@ public:
 	std::list<TuioCursor25D*> jointCursor25DList;
 	std::list<TuioCursor25D*> activeCursor25DList;
 
-	int object25DID = 0;
+	int object25DID;
 	std::list<TuioObject25D*> stickyObject25DList;
 	std::list<TuioObject25D*> jointObject25DList;
 	std::list<TuioObject25D*> activeObject25DList;
@@ -88,7 +88,7 @@ public:
 	std::list<TuioCursor3D*> jointCursor3DList;
 	std::list<TuioCursor3D*> activeCursor3DList;
 
-	int object3DID = 0;
+	int object3DID;
 	std::list<TuioObject3D*> stickyObject3DList;
 	std::list<TuioObject3D*> jointObject3DList;
 	std::list<TuioObject3D*> activeObject3DList;

--- a/SimpleSimulator.h
+++ b/SimpleSimulator.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Server Demo
  Copyright (c) 2005-2016 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
  
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/SimpleSimulator.h
+++ b/SimpleSimulator.h
@@ -52,9 +52,50 @@ public:
 	
 	void run();
 	TuioServer *tuioServer;
+	int mode = 0; // 0: 2Dcur; 1: 2Dobj; 2: 2Dblb; 3: 25Dcur; 4: 25Dobj; 5: 25Dblb; 6: 3Dcur; 7: 3Dobj; 8: 3Dblb
+	int control = 0;// 0: z; 1: roll/angle; 2: pitch; 3: yaw; 4: width; 5: height; 6: depth
+
 	std::list<TuioCursor*> stickyCursorList;
 	std::list<TuioCursor*> jointCursorList;
 	std::list<TuioCursor*> activeCursorList;
+
+	int objectID = 0;
+	std::list<TuioObject*> stickyObjectList;
+	std::list<TuioObject*> jointObjectList;
+	std::list<TuioObject*> activeObjectList;
+
+	std::list<TuioBlob*> stickyBlobList;
+	std::list<TuioBlob*> jointBlobList;
+	std::list<TuioBlob*> activeBlobList;
+
+
+	std::list<TuioCursor25D*> stickyCursor25DList;
+	std::list<TuioCursor25D*> jointCursor25DList;
+	std::list<TuioCursor25D*> activeCursor25DList;
+
+	int object25DID = 0;
+	std::list<TuioObject25D*> stickyObject25DList;
+	std::list<TuioObject25D*> jointObject25DList;
+	std::list<TuioObject25D*> activeObject25DList;
+
+	std::list<TuioBlob25D*> stickyBlob25DList;
+	std::list<TuioBlob25D*> jointBlob25DList;
+	std::list<TuioBlob25D*> activeBlob25DList;
+
+
+
+	std::list<TuioCursor3D*> stickyCursor3DList;
+	std::list<TuioCursor3D*> jointCursor3DList;
+	std::list<TuioCursor3D*> activeCursor3DList;
+
+	int object3DID = 0;
+	std::list<TuioObject3D*> stickyObject3DList;
+	std::list<TuioObject3D*> jointObject3DList;
+	std::list<TuioObject3D*> activeObject3DList;
+
+	std::list<TuioBlob3D*> stickyBlob3DList;
+	std::list<TuioBlob3D*> jointBlob3DList;
+	std::list<TuioBlob3D*> activeBlob3DList;
 	
 private:
 	void drawFrame();
@@ -74,6 +115,7 @@ private:
 	void mousePressed(float x, float y);
 	void mouseReleased(float x, float y);
 	void mouseDragged(float x, float y);
+	void applyExtraDimension(float scroll);
 	//int s_id;
 };
 

--- a/TUIO/TuioBLob25D.h
+++ b/TUIO/TuioBLob25D.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioBlob by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioBLob25D.h
+++ b/TUIO/TuioBLob25D.h
@@ -16,137 +16,141 @@
  License along with this library.
 */
 
-#ifndef INCLUDED_TUIOBLOB_H
-#define INCLUDED_TUIOBLOB_H
+#ifndef INCLUDED_TUIOBLOB25D_H
+#define INCLUDED_TUIOBLOB25D_H
 
 #include "TuioContainer.h"
 
 namespace TUIO {
-	
+
 	/**
-	 * The TuioBlob class encapsulates /tuio/2Dblb TUIO objects.
+	 * The TuioBlob2.5D class encapsulates /tuio/25Dblb TUIO objects.
 	 *
 	 * @author Nicolas Bremard
 	 * @version 1.1.7
-	 */ 
-	class LIBDECL TuioBlob: public TuioContainer {
-		
+	 */
+	class LIBDECL TuioBlob25D : public TuioContainer {
+
 	protected:
 		/**
-		 * The individual blob ID number that is assigned to each TuioBlob.
-		 */ 
+		 * The individual blob ID number that is assigned to each TuioBlob25D.
+		 */
 		int blob_id;
 		/**
 		 * The rotation angle value.
-		 */ 
+		 */
 		float angle;
 		/**
 		 * The width value.
-		 */ 
+		 */
 		float width;
 		/**
 		 * The height value.
-		 */ 
+		 */
 		float height;
 		/**
 		 * The area value.
-		 */ 
+		 */
 		float area;
 		/**
 		 * The rotation speed value.
-		 */ 
+		 */
 		float rotation_speed;
 		/**
 		 * The rotation acceleration value.
-		 */ 
+		 */
 		float rotation_accel;
-		
+
 		float angleThreshold;
 		OneEuroFilter *angleFilter;
 		float sizeThreshold;
 		OneEuroFilter *widthFilter;
 		OneEuroFilter *heightFilter;
-		
+
 	public:
 		using TuioContainer::update;
 
 		/**
-		 * This constructor takes a TuioTime argument and assigns it along with the provided 
-		 * Session ID, X and Y coordinate, width, height and angle to the newly created TuioBlob.
+		 * This constructor takes a TuioTime argument and assigns it along with the provided
+		 * Session ID, X and Y coordinate, width, height and angle to the newly created TuioBlob25D.
 		 *
 		 * @param	ttime	the TuioTime to assign
 		 * @param	si	the Session ID  to assign
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 * @param	a	the angle to assign
 		 * @param	w	the width to assign
 		 * @param	h	the height to assign
 		 * @param	f	the area to assign
 		 */
-		TuioBlob (TuioTime ttime, long si, int bi, float xp, float yp, float a, float w, float h, float f);
+		TuioBlob25D(TuioTime ttime, long si, int bi, float xp, float yp, float zp, float a, float w, float h, float f);
 
 		/**
-		 * This constructor takes the provided Session ID, X and Y coordinate 
-		 *  width, height and angle, and assigs these values to the newly created TuioBlob.
+		 * This constructor takes the provided Session ID, X and Y coordinate
+		 *  width, height and angle, and assigs these values to the newly created TuioBlob25D.
 		 *
 		 * @param	si	the Session ID  to assign
 		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
 		 * @param	yp	the Y coordinate to assign
 		 * @param	a	the angle to assign
 		 * @param	w	the width to assign
 		 * @param	h	the height to assign
 		 * @param	f	the area to assign
-		 */	
-		TuioBlob (long si, int bi, float xp, float yp, float a, float  w, float h, float f);
-		
+		 */
+		TuioBlob25D(long si, int bi, float xp, float yp, float zp, float a, float  w, float h, float f);
+
 		/**
-		 * This constructor takes the atttibutes of the provided TuioBlob 
-		 * and assigs these values to the newly created TuioBlob.
+		 * This constructor takes the atttibutes of the provided TuioBlob25D
+		 * and assigs these values to the newly created TuioBlob25D.
 		 *
-		 * @param	tblb	the TuioBlob to assign
+		 * @param	tblb	the TuioBlob25D to assign
 		 */
-		TuioBlob (TuioBlob *tblb);
-		
+		TuioBlob25D(TuioBlob25D *tblb);
+
 		/**
-		 * The destructor is doing nothing in particular. 
+		 * The destructor is doing nothing in particular.
 		 */
-		virtual ~TuioBlob() {
+		virtual ~TuioBlob25D() {
 			if (widthFilter) delete widthFilter;
 			if (heightFilter) delete heightFilter;
 			if (angleFilter) delete angleFilter;
 		};
 
 		/**
-		 * Returns the Blob ID of this TuioBlob.
-		 * @return	the Blob ID of this TuioBlob
+		 * Returns the Blob ID of this TuioBlob25D.
+		 * @return	the Blob ID of this TuioBlob25D
 		 */
 		int getBlobID() const;
-		
+
 		/**
-		 * Sets the Blob ID of this TuioBlob.
-		 * @param bi	the new Blob ID for this TuioBlob
+		 * Sets the Blob ID of this TuioBlob25D.
+		 * @param bi	the new Blob ID for this TuioBlob25D
 		 */
 		void setBlobID(int bi);
-		
+
 		/**
-		 * Takes a TuioTime argument and assigns it along with the provided 
+		 * Takes a TuioTime argument and assigns it along with the provided
 		 * X and Y coordinate, angle, X and Y velocity, motion acceleration,
-		 * rotation speed and rotation acceleration to the private TuioBlob attributes.
+		 * rotation speed and rotation acceleration to the private TuioBlob25D attributes.
 		 *
 		 * @param	ttime	the TuioTime to assign
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 * @param	a	the rotation angle to assign
 		 * @param	w	the width to assign
 		 * @param	h	the height to assign
 		 * @param	f	the area to assign
 		 * @param	xs	the X velocity to assign
 		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
 		 * @param	rs	the rotation velocity to assign
 		 * @param	ma	the motion acceleration to assign
 		 * @param	ra	the rotation acceleration to assign
 		 */
-		void update (TuioTime ttime, float xp, float yp, float a, float w, float h, float f, float xs, float ys, float rs, float ma, float ra);
+		void update(TuioTime ttime, float xp, float yp, float zp, float a, float w, float h, float f, float xs, float ys, float zs, float rs, float ma, float ra);
 
 		/**
 		 * Assigns the provided X and Y coordinate, angle, X and Y velocity, motion acceleration
@@ -155,122 +159,125 @@ namespace TUIO {
 		 *
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 * @param	a	the angle to assign
 		 * @param	w	the width to assign
 		 * @param	h	the height to assign
 		 * @param	f	the area to assign
 		 * @param	xs	the X velocity to assign
 		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
 		 * @param	rs	the rotation velocity to assign
 		 * @param	ma	the motion acceleration to assign
 		 * @param	ra	the rotation acceleration to assign
 		 */
-		void update (float xp, float yp, float a, float w, float h, float f, float xs, float ys, float rs, float ma, float ra);
-		
+		void update(float xp, float yp, float zp, float a, float w, float h, float f, float xs, float ys, float zs, float rs, float ma, float ra);
+
 		/**
-		 * Takes a TuioTime argument and assigns it along with the provided 
-		 * X and Y coordinate and angle to the private TuioBlob attributes.
+		 * Takes a TuioTime argument and assigns it along with the provided
+		 * X and Y coordinate and angle to the private TuioBlob25D attributes.
 		 * The speed and accleration values are calculated accordingly.
 		 *
 		 * @param	ttime	the TuioTime to assign
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 * @param	a	the angle coordinate to assign
 		 * @param	w	the width to assign
 		 * @param	h	the height to assign
 		 * @param	f	the area to assign
 		 */
-		void update (TuioTime ttime, float xp, float yp, float a, float w, float h, float f);
+		void update(TuioTime ttime, float xp, float yp, float zp, float a, float w, float h, float f);
 
 		/**
 		 * This method is used to calculate the speed and acceleration values of a
-		 * TuioBlob with unchanged position and angle.
+		 * TuioBlob25D with unchanged position and angle.
 		 */
-		void stop (TuioTime ttime);
-		
+		void stop(TuioTime ttime);
+
 		/**
-		 * Takes the atttibutes of the provided TuioBlob 
-		 * and assigs these values to this TuioBlob.
+		 * Takes the atttibutes of the provided TuioBlob25D
+		 * and assigs these values to this TuioBlob25D.
 		 * The TuioTime time stamp of this TuioContainer remains unchanged.
 		 *
 		 * @param	tblb	the TuioContainer to assign
-		 */	
-		void update (TuioBlob *tblb);
-		
+		 */
+		void update(TuioBlob25D *tblb);
+
 		/**
-		 * Returns the width of this TuioBlob.
-		 * @return	the width of this TuioBlob
+		 * Returns the width of this TuioBlob25D.
+		 * @return	the width of this TuioBlob25D
 		 */
 		float getWidth() const;
 
 		/**
-		 * Returns the height of this TuioBlob.
-		 * @return	the height of this TuioBlob
+		 * Returns the height of this TuioBlob25D.
+		 * @return	the height of this TuioBlob25D
 		 */
 		float getHeight() const;
 
 		/**
-		 * Returns the width of this TuioBlob in real unit.
-		 * @return	the width of this TuioBlob
+		 * Returns the width of this TuioBlob25D in real unit.
+		 * @return	the width of this TuioBlob25D
 		 */
-		int getScreenWidth(int w) const;
-		
+		int getSpaceWidth(int w) const;
+
 		/**
-		 * Returns the height of this TuioBlob in real unit.
-		 * @return	the height of this TuioBlob
+		 * Returns the height of this TuioBlob25D in real unit.
+		 * @return	the height of this TuioBlob25D
 		 */
-		int getScreenHeight(int h) const;
-		
+		int getSpaceHeight(int h) const;
+
 		/**
-		 * Returns the area of this TuioBlob.
-		 * @return	the area of this TuioBlob
+		 * Returns the area of this TuioBlob25D.
+		 * @return	the area of this TuioBlob25D
 		 */
 		float getArea() const;
-		
+
 		/**
-		 * Returns the rotation angle of this TuioBlob.
-		 * @return	the rotation angle of this TuioBlob
+		 * Returns the rotation angle of this TuioBlob25D.
+		 * @return	the rotation angle of this TuioBlob25D
 		 */
 		float getAngle() const;
-		
+
 		/**
-		 * Returns the rotation angle in degrees of this TuioBlob.
-		 * @return	the rotation angle in degrees of this TuioBlob
+		 * Returns the rotation angle in degrees of this TuioBlob25D.
+		 * @return	the rotation angle in degrees of this TuioBlob25D
 		 */
 		float getAngleDegrees() const;
-		
+
 		/**
-		 * Returns the rotation speed of this TuioBlob.
-		 * @return	the rotation speed of this TuioBlob
+		 * Returns the rotation speed of this TuioBlob25D.
+		 * @return	the rotation speed of this TuioBlob25D
 		 */
 		float getRotationSpeed() const;
-		
+
 		/**
-		 * Returns the rotation acceleration of this TuioBlob.
-		 * @return	the rotation acceleration of this TuioBlob
+		 * Returns the rotation acceleration of this TuioBlob25D.
+		 * @return	the rotation acceleration of this TuioBlob25D
 		 */
 		float getRotationAccel() const;
 
 		/**
-		 * Returns true of this TuioBlob is moving.
-		 * @return	true of this TuioBlob is moving
+		 * Returns true of this TuioBlob25D is moving.
+		 * @return	true of this TuioBlob25D is moving
 		 */
 		bool isMoving() const;
-		
+
 		void addAngleThreshold(float thresh);
-		
+
 		void removeAngleThreshold();
-		
+
 		void addAngleFilter(float mcut, float beta);
-		
+
 		void removeAngleFilter();
-		
+
 		void addSizeThreshold(float thresh);
-		
+
 		void removeSizeThreshold();
-		
+
 		void addSizeFilter(float mcut, float beta);
-		
+
 		void removeSizeFilter();
 	};
 }

--- a/TUIO/TuioBlob.cpp
+++ b/TUIO/TuioBlob.cpp
@@ -1,6 +1,6 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioBlob.h
+++ b/TUIO/TuioBlob.h
@@ -1,6 +1,6 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -26,9 +26,9 @@ namespace TUIO {
 	/**
 	 * The TuioBlob class encapsulates /tuio/2Dblb TUIO objects.
 	 *
-	 * @author Nicolas Bremard
-	 * @version 1.1.7
-	 */ 
+	 * @author Martin Kaltenbrunner
+	 * @version 1.1.6
+	 */
 	class LIBDECL TuioBlob: public TuioContainer {
 		
 	protected:

--- a/TUIO/TuioBlob25D.cpp
+++ b/TUIO/TuioBlob25D.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioBlob by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioBlob25D.cpp
+++ b/TUIO/TuioBlob25D.cpp
@@ -1,0 +1,254 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#include "TuioBlob25D.h"
+
+using namespace TUIO;
+
+TuioBlob25D::TuioBlob25D(TuioTime ttime, long si, int bi, float xp, float yp, float zp, float a, float w, float h, float f) :TuioContainer(ttime, si, xp, yp, zp) {
+	blob_id = bi;
+	angle = a;
+	width = w;
+	height = h;
+	area = f;
+	rotation_speed = 0.0f;
+	rotation_accel = 0.0f;
+
+	angleFilter = NULL;
+	angleThreshold = 0.0f;
+	widthFilter = NULL;
+	heightFilter = NULL;
+	sizeThreshold = 0.0f;
+}
+
+TuioBlob25D::TuioBlob25D(long si, int bi, float xp, float yp, float zp, float a, float  w, float h, float f) :TuioContainer(si, xp, yp, zp) {
+	blob_id = bi;
+	angle = a;
+	width = w;
+	height = h;
+	area = f;
+	rotation_speed = 0.0f;
+	rotation_accel = 0.0f;
+
+	angleFilter = NULL;
+	angleThreshold = 0.0f;
+	widthFilter = NULL;
+	heightFilter = NULL;
+	sizeThreshold = 0.0f;
+}
+
+TuioBlob25D::TuioBlob25D(TuioBlob25D *tblb) :TuioContainer(tblb) {
+	blob_id = tblb->getBlobID();
+	angle = tblb->getAngle();
+	width = tblb->getWidth();
+	height = tblb->getHeight();
+	area = tblb->getArea();
+	rotation_speed = 0.0f;
+	rotation_accel = 0.0f;
+
+	angleFilter = NULL;
+	angleThreshold = 0.0f;
+	widthFilter = NULL;
+	heightFilter = NULL;
+	sizeThreshold = 0.0f;
+}
+
+int TuioBlob25D::getBlobID() const {
+	return blob_id;
+}
+
+void TuioBlob25D::setBlobID(int bi) {
+	blob_id = bi;
+}
+
+void TuioBlob25D::update(TuioTime ttime, float xp, float yp, float zp, float a, float w, float h, float f, float xs, float ys, float zs, float rs, float ma, float ra) {
+	TuioContainer::update(ttime, xp, yp, zp, xs, ys, zs, ma);
+	angle = a;
+	float dw = width - w;
+	float dh = height - h;
+	width = w;
+	height = h;
+	area = f;
+	rotation_speed = rs;
+	rotation_accel = ra;
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+	if (dw != 0 || dh != 0) state = TUIO_RESIZED; // If size change -> update data
+}
+
+void TuioBlob25D::update(float xp, float yp, float zp, float a, float w, float h, float f, float xs, float ys, float zs, float rs, float ma, float ra) {
+	TuioContainer::update(xp, yp, zp, xs, ys, zs, ma);
+	angle = a;
+	float dw = width - w;
+	float dh = height - h;
+	width = w;
+	height = h;
+	area = f;
+	rotation_speed = rs;
+	rotation_accel = ra;
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+	if (dw != 0 || dh != 0) state = TUIO_RESIZED; // If size change -> update data
+}
+
+void TuioBlob25D::update(TuioTime ttime, float xp, float yp, float zp, float a, float w, float h, float f) {
+	TuioPoint lastPoint = path.back();
+	TuioContainer::update(ttime, xp, yp, zp);
+
+	TuioTime diffTime = currentTime - lastPoint.getTuioTime();
+	float dt = diffTime.getTotalMilliseconds() / 1000.0f;
+	float last_rotation_speed = rotation_speed;
+
+	float da = a - angle;
+	if (da > M_PI) da -= 2 * M_PI;
+	else if (da < -M_PI) da += 2 * M_PI;
+
+	float prev_angle = angle;
+	if (angleFilter) angle = angleFilter->filter(angle + da, dt);
+	else angle = angle + da;
+	if (fabs(angle - prev_angle) < angleThreshold) angle = prev_angle;
+
+	if (angle > 2 * M_PI) angle -= 2 * M_PI;
+	else if (angle < 0) angle += 2 * M_PI;
+
+	da = angle - prev_angle;
+	if (da > M_PI) da -= 2 * M_PI;
+	else if (da < -M_PI) da += 2 * M_PI;
+	da = da / (2 * M_PI);
+
+	angle = a;
+
+	if (widthFilter && heightFilter) {
+		w = widthFilter->filter(w, dt);
+		h = heightFilter->filter(h, dt);
+	}
+
+	float dw = fabs(width - w);
+	float dh = fabs(height - h);
+	if ((dw > sizeThreshold) || (dh > sizeThreshold)) {
+		width = w;
+		height = h;
+	}
+
+	area = f;
+
+	rotation_speed = (float)da / dt;
+	rotation_accel = (rotation_speed - last_rotation_speed) / dt;
+
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+	if(dw!=0 || dh != 0) state = TUIO_RESIZED; // If size change -> update data
+}
+
+void TuioBlob25D::stop(TuioTime ttime) {
+	update(ttime, xpos, ypos, zpos, angle, width, height, area);
+}
+
+void TuioBlob25D::update(TuioBlob25D *tblb) {
+	TuioContainer::update(tblb);
+	angle = tblb->getAngle();
+	width = tblb->getWidth();
+	height = tblb->getHeight();
+	area = tblb->getArea();
+	rotation_speed = tblb->getRotationSpeed();
+	rotation_accel = tblb->getRotationAccel();
+	state = tblb->getTuioState();
+}
+
+float TuioBlob25D::getWidth() const {
+	return width;
+}
+
+float TuioBlob25D::getHeight() const {
+	return height;
+}
+
+int TuioBlob25D::getSpaceWidth(int w) const {
+	return (int)(w*width);
+}
+
+int TuioBlob25D::getSpaceHeight(int h) const {
+	return (int)(h*height);
+}
+
+float TuioBlob25D::getArea() const {
+	return area;
+}
+
+float TuioBlob25D::getAngle() const {
+	return angle;
+}
+
+float TuioBlob25D::getAngleDegrees() const {
+	return (float)(angle / M_PI * 180);
+}
+
+float TuioBlob25D::getRotationSpeed() const {
+	return rotation_speed;
+}
+
+float TuioBlob25D::getRotationAccel() const {
+	return rotation_accel;
+}
+
+bool TuioBlob25D::isMoving() const {
+	if ((state == TUIO_ACCELERATING) || (state == TUIO_DECELERATING) || (state == TUIO_ROTATING) || (state == TUIO_RESIZED)) return true;
+	else return false;
+}
+
+void TuioBlob25D::addAngleThreshold(float thresh) {
+	angleThreshold = thresh;
+}
+
+void TuioBlob25D::removeAngleThreshold() {
+	angleThreshold = 0.0f;
+}
+
+void TuioBlob25D::addAngleFilter(float mcut, float beta) {
+
+	if (angleFilter) delete angleFilter;
+	angleFilter = new OneEuroFilter(60.0f, mcut, beta, 1.0f);
+}
+
+void TuioBlob25D::removeAngleFilter() {
+
+	if (angleFilter) delete angleFilter;
+	angleFilter = NULL;
+}
+
+void TuioBlob25D::addSizeThreshold(float thresh) {
+	sizeThreshold = thresh;
+}
+
+void TuioBlob25D::removeSizeThreshold() {
+	sizeThreshold = 0.0f;
+}
+
+void TuioBlob25D::addSizeFilter(float mcut, float beta) {
+
+	if (widthFilter) delete widthFilter;
+	widthFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+	if (heightFilter) delete heightFilter;
+	heightFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioBlob25D::removeSizeFilter() {
+
+	if (widthFilter) delete widthFilter;
+	widthFilter = NULL;
+	if (heightFilter) delete heightFilter;
+	heightFilter = NULL;
+}
+

--- a/TUIO/TuioBlob3D.cpp
+++ b/TUIO/TuioBlob3D.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioBlob by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioBlob3D.cpp
+++ b/TUIO/TuioBlob3D.cpp
@@ -1,0 +1,538 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#include "TuioBlob3D.h"
+
+using namespace TUIO;
+
+TuioBlob3D::TuioBlob3D(TuioTime ttime, long si, int bi, float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v) :TuioContainer(ttime, si, xp, yp, zp) {
+	blob_id = bi;
+
+	roll = ro;
+	pitch = po;
+	yaw = yo;
+	roll_speed = 0.0f;
+	pitch_speed = 0.0f;
+	yaw_speed = 0.0f;
+	roll_accel = 0.0f;
+	pitch_accel = 0.0f;
+	yaw_accel = 0.0f;
+	rollFilter = NULL;
+	pitchFilter = NULL;
+	yawFilter = NULL;
+	rollThreshold = 0.0f;
+	pitchThreshold = 0.0f;
+	yawThreshold = 0.0f;
+
+	rotation_accel = 0.0f;
+
+
+	width = w;
+	height = h;
+	depth = d;
+	volume = v;
+	widthFilter = NULL;
+	heightFilter = NULL;
+	depthFilter = NULL;
+	widthThreshold = 0.0f;
+	heightThreshold = 0.0f;
+	depthThreshold = 0.0f;
+
+}
+
+TuioBlob3D::TuioBlob3D(long si, int bi, float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v) :TuioContainer(si, xp, yp, zp) {
+	blob_id = bi;
+
+	roll = ro;
+	pitch = po;
+	yaw = yo;
+	roll_speed = 0.0f;
+	pitch_speed = 0.0f;
+	yaw_speed = 0.0f;
+	roll_accel = 0.0f;
+	pitch_accel = 0.0f;
+	yaw_accel = 0.0f;
+	rollFilter = NULL;
+	pitchFilter = NULL;
+	yawFilter = NULL;
+	rollThreshold = 0.0f;
+	pitchThreshold = 0.0f;
+	yawThreshold = 0.0f;
+
+	rotation_accel = 0.0f;
+
+
+	width = w;
+	height = h;
+	depth = d;
+	volume = v;
+	widthFilter = NULL;
+	heightFilter = NULL;
+	depthFilter = NULL;
+	widthThreshold = 0.0f;
+	heightThreshold = 0.0f;
+	depthThreshold = 0.0f;
+}
+
+TuioBlob3D::TuioBlob3D(TuioBlob3D *tblb) :TuioContainer(tblb) {
+	blob_id = tblb->getBlobID();
+
+	volume = tblb->getVolume();
+
+	roll = tblb->getRoll();
+	pitch = tblb->getPitch();
+	yaw = tblb->getYaw();
+	roll_speed = tblb->getRollSpeed();
+	pitch_speed = tblb->getPitchSpeed();
+	yaw_speed = tblb->getYawSpeed();
+	roll_accel = tblb->getRollAccel();
+	pitch_accel = tblb->getPitchAccel();
+	yaw_accel = tblb->getYawAccel();
+
+	rotation_accel = tblb->getRotationAccel();
+
+	rollFilter = NULL;
+	pitchFilter = NULL;
+	yawFilter = NULL;
+	rollThreshold = 0.0f;
+	pitchThreshold = 0.0f;
+	yawThreshold = 0.0f;
+
+
+	width = tblb->getWidth();
+	height = tblb->getHeight();
+	depth = tblb->getDepth();
+
+	widthFilter = NULL;
+	heightFilter = NULL;
+	depthFilter = NULL;
+	widthThreshold = 0.0f;
+	heightThreshold = 0.0f;
+	depthThreshold = 0.0f;
+}
+
+int TuioBlob3D::getBlobID() const {
+	return blob_id;
+}
+
+void TuioBlob3D::setBlobID(int bi) {
+	blob_id = bi;
+}
+
+void TuioBlob3D::update(TuioTime ttime, float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v, float xs, float ys, float zs, float ros, float pos, float yos, float ma, float ra) {
+	TuioContainer::update(ttime, xp, yp, zp, xs, ys, zs, ma);
+	roll = ro;
+	pitch = po;
+	yaw = yo;
+	roll_speed = ros;
+	yaw_speed = pos;
+	pitch_speed = yos;
+
+
+	float dw = width - w;
+	float dh = height - h;
+	float dd = depth - d;
+	width = w;
+	height = h;
+	depth = d;
+	volume = v;
+
+	rotation_accel = ra;
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+	if (dw != 0 || dh != 0 || dd != 0) state = TUIO_RESIZED; // If size change -> update data
+}
+
+void TuioBlob3D::update(float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v, float xs, float ys, float zs, float ros, float pos, float yos, float ma, float ra) {
+	TuioContainer::update(xp, yp, zp, xs, ys, zs, ma);
+	roll = ro;
+	pitch = po;
+	yaw = yo;
+	roll_speed = ros;
+	yaw_speed = pos;
+	pitch_speed = yos;
+
+	float dw = width - w;
+	float dh = height - h;
+	float dd = depth - d;
+	width = w;
+	height = h;
+	depth = d;
+	volume = v;
+
+	rotation_accel = ra;
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+	if (dw != 0 || dh != 0 || dd != 0) state = TUIO_RESIZED; // If size change -> update data
+}
+
+void TuioBlob3D::update(TuioTime ttime, float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v) {
+	TuioPoint lastPoint = path.back();
+	TuioContainer::update(ttime, xp, yp, zp);
+
+	TuioTime diffTime = currentTime - lastPoint.getTuioTime();
+	float dt = diffTime.getTotalMilliseconds() / 1000.0f;
+
+
+	float last_roll_speed = roll_speed;
+	float dr = ro - roll;
+	if (dr > M_PI) dr -= 2 * M_PI;
+	else if (dr < -M_PI) dr += 2 * M_PI;
+
+	float prev_roll = roll;
+	if (rollFilter) roll = rollFilter->filter(roll + dr, dt);
+	else roll = roll + dr;
+	if (fabs(roll - prev_roll) < rollThreshold) roll = prev_roll;
+
+	if (roll > 2 * M_PI) roll -= 2 * M_PI;
+	else if (roll < 0) roll += 2 * M_PI;
+
+	dr = roll - prev_roll;
+	if (dr > M_PI) dr -= 2 * M_PI;
+	else if (dr < -M_PI) dr += 2 * M_PI;
+	dr = dr / (2 * M_PI);
+
+	roll_speed = (float)dr / dt;
+	roll_accel = (roll_speed - last_roll_speed) / dt;
+
+
+	float last_pitch_speed = pitch_speed;
+	float dp = po - pitch;
+	if (dp > M_PI) dp -= 2 * M_PI;
+	else if (dp < -M_PI) dp += 2 * M_PI;
+
+	float prev_pitch = pitch;
+	if (pitchFilter) pitch = pitchFilter->filter(pitch + dp, dt);
+	else pitch = pitch + dp;
+	if (fabs(pitch - prev_pitch) < pitchThreshold) pitch = prev_pitch;
+
+	if (pitch > 2 * M_PI) pitch -= 2 * M_PI;
+	else if (pitch < 0) pitch += 2 * M_PI;
+
+	dp = pitch - prev_pitch;
+	if (dp > M_PI) dp -= 2 * M_PI;
+	else if (dp < -M_PI) dp += 2 * M_PI;
+	dp = dp / (2 * M_PI);
+
+	pitch_speed = (float)dp / dt;
+	pitch_accel = (pitch_speed - last_pitch_speed) / dt;
+
+
+	float last_yaw_speed = yaw_speed;
+	float dy = yo - yaw;
+	if (dy > M_PI) dy -= 2 * M_PI;
+	else if (dy < -M_PI) dy += 2 * M_PI;
+
+	float prev_yaw = yaw;
+	if (yawFilter) yaw = yawFilter->filter(yaw + dy, dt);
+	else yaw = yaw + dy;
+	if (fabs(yaw - prev_yaw) < yawThreshold) yaw = prev_yaw;
+
+	if (yaw > 2 * M_PI) yaw -= 2 * M_PI;
+	else if (yaw < 0) yaw += 2 * M_PI;
+
+	dy = yaw - prev_yaw;
+	if (dy > M_PI) dy -= 2 * M_PI;
+	else if (dy < -M_PI) dy += 2 * M_PI;
+	dy = dy / (2 * M_PI);
+
+	yaw_speed = (float)dy / dt;
+	yaw_accel = (yaw_speed - last_yaw_speed) / dt;
+
+	roll = ro;
+	pitch = po;
+	yaw = yo;
+
+	rotation_accel = (roll_accel + pitch_accel + yaw_accel) / 3;
+
+	if (((roll != 0) || (pitch != 0) || (yaw != 0)) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+
+
+
+
+	if (widthFilter && heightFilter && depthFilter) {
+		w = widthFilter->filter(w, dt);
+		h = heightFilter->filter(h, dt);
+		d = depthFilter->filter(d, dt);
+	}
+
+	float dw = fabs(width - w);
+	float dh = fabs(height - h);
+	float dd = fabs(depth - d);
+	if ((dw > widthThreshold) || (dh > heightThreshold) || (dd > depthThreshold)) {
+		width = w;
+		height = h;
+		depth = d;
+	}
+
+
+	if (dw != 0 || dh != 0 || dd != 0) state = TUIO_RESIZED; // If size change -> update data
+
+	volume = v;
+
+}
+
+void TuioBlob3D::stop(TuioTime ttime) {
+	update(ttime, xpos, ypos, zpos, roll, pitch, yaw , width, height, depth, volume);
+}
+
+void TuioBlob3D::update(TuioBlob3D *tblb) {
+	TuioContainer::update(tblb);
+
+	roll = tblb->getRoll();
+	pitch = tblb->getPitch();
+	yaw = tblb->getYaw();
+	roll_speed = tblb->getRollSpeed();
+	pitch_speed = tblb->getPitchSpeed();
+	yaw_speed = tblb->getYawSpeed();
+	roll_accel = tblb->getRollAccel();
+	pitch_accel = tblb->getPitchAccel();
+	yaw_accel = tblb->getYawAccel();
+	rotation_accel = tblb->getRotationAccel();
+
+	state = tblb->getTuioState();
+
+
+	width = tblb->getWidth();
+	height = tblb->getHeight();
+	depth = tblb->getDepth();
+	volume = tblb->getVolume();
+
+}
+
+float TuioBlob3D::getWidth() const {
+	return width;
+}
+
+float TuioBlob3D::getHeight() const {
+	return height;
+}
+
+float TuioBlob3D::getDepth() const {
+	return depth;
+}
+
+
+int TuioBlob3D::getSpaceWidth(int w) const {
+	return (int)(w*width);
+}
+
+int TuioBlob3D::getSpaceHeight(int h) const {
+	return (int)(h*height);
+}
+
+int TuioBlob3D::getSpaceDepth(int d) const {
+	return (int)(d*depth);
+}
+
+float TuioBlob3D::getVolume() const {
+	return volume;
+}
+
+
+
+float TuioBlob3D::getRoll() const {
+	return roll;
+}
+
+float TuioBlob3D::getRollDegrees() const {
+	return (float)(roll / M_PI * 180);
+}
+
+float TuioBlob3D::getRollSpeed() const {
+	return roll_speed;
+}
+
+float TuioBlob3D::getRollAccel() const {
+	return roll_accel;
+}
+
+float TuioBlob3D::getPitch() const {
+	return pitch;
+}
+
+float TuioBlob3D::getPitchDegrees() const {
+	return (float)(pitch / M_PI * 180);
+}
+
+float TuioBlob3D::getPitchSpeed() const {
+	return pitch_speed;
+}
+
+float TuioBlob3D::getPitchAccel() const {
+	return pitch_accel;
+}
+
+float TuioBlob3D::getYaw() const {
+	return yaw;
+}
+
+float TuioBlob3D::getYawDegrees() const {
+	return (float)(yaw / M_PI * 180);
+}
+
+float TuioBlob3D::getYawSpeed() const {
+	return yaw_speed;
+}
+
+float TuioBlob3D::getYawAccel() const {
+	return yaw_accel;
+}
+
+float TuioBlob3D::getRotationAccel() const {
+	return rotation_accel;
+}
+
+
+
+bool TuioBlob3D::isMoving() const {
+	if ((state == TUIO_ACCELERATING) || (state == TUIO_DECELERATING) || (state == TUIO_ROTATING) || (state == TUIO_RESIZED)) return true;
+	else return false;
+}
+
+
+void TuioBlob3D::addRollThreshold(float thresh) {
+	rollThreshold = thresh;
+}
+
+void TuioBlob3D::addPitchThreshold(float thresh) {
+	pitchThreshold = thresh;
+}
+
+void TuioBlob3D::addYawThreshold(float thresh) {
+	yawThreshold = thresh;
+}
+
+
+void TuioBlob3D::removeRollThreshold() {
+	rollThreshold = 0.0f;
+}
+
+void TuioBlob3D::removePitchThreshold() {
+	pitchThreshold = 0.0f;
+}
+
+void TuioBlob3D::removeYawThreshold() {
+	yawThreshold = 0.0f;
+}
+void TuioBlob3D::addRollFilter(float mcut, float beta) {
+
+	if (rollFilter) delete rollFilter;
+	rollFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioBlob3D::addPitchFilter(float mcut, float beta) {
+
+	if (pitchFilter) delete pitchFilter;
+	pitchFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioBlob3D::addYawFilter(float mcut, float beta) {
+
+	if (yawFilter) delete yawFilter;
+	yawFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioBlob3D::removeRollFilter() {
+
+	if (rollFilter) delete rollFilter;
+	rollFilter = NULL;
+}
+
+void TuioBlob3D::removePitchFilter() {
+
+	if (pitchFilter) delete pitchFilter;
+	pitchFilter = NULL;
+}
+
+void TuioBlob3D::removeYawFilter() {
+
+	if (yawFilter) delete yawFilter;
+	yawFilter = NULL;
+}
+
+
+
+
+
+
+
+void TuioBlob3D::addWidthThreshold(float thresh) {
+	widthThreshold = thresh;
+}
+
+void TuioBlob3D::addHeightThreshold(float thresh) {
+	heightThreshold = thresh;
+}
+
+void TuioBlob3D::addDepthThreshold(float thresh) {
+	depthThreshold = thresh;
+}
+
+
+void TuioBlob3D::removeWidthThreshold() {
+	widthThreshold = 0.0f;
+}
+
+void TuioBlob3D::removeHeightThreshold() {
+	heightThreshold = 0.0f;
+}
+
+void TuioBlob3D::removeDepthThreshold() {
+	depthThreshold = 0.0f;
+}
+void TuioBlob3D::addWidthFilter(float mcut, float beta) {
+
+	if (widthFilter) delete widthFilter;
+	widthFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioBlob3D::addHeightFilter(float mcut, float beta) {
+
+	if (heightFilter) delete heightFilter;
+	heightFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioBlob3D::addDepthFilter(float mcut, float beta) {
+
+	if (depthFilter) delete depthFilter;
+	depthFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioBlob3D::removeWidthFilter() {
+
+	if (widthFilter) delete widthFilter;
+	widthFilter = NULL;
+}
+
+void TuioBlob3D::removeHeightFilter() {
+
+	if (heightFilter) delete heightFilter;
+	heightFilter = NULL;
+}
+
+void TuioBlob3D::removeDepthFilter() {
+
+	if (depthFilter) delete depthFilter;
+	depthFilter = NULL;
+}
+
+
+
+
+
+
+

--- a/TUIO/TuioBlob3D.h
+++ b/TUIO/TuioBlob3D.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioBlob by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioBlob3D.h
+++ b/TUIO/TuioBlob3D.h
@@ -1,0 +1,443 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#ifndef INCLUDED_TUIOBLOB3D_H
+#define INCLUDED_TUIOBLOB3D_H
+
+#include "TuioContainer.h"
+
+namespace TUIO {
+
+	/**
+	 * The TuioBlob3D class encapsulates /tuio/3Dblb TUIO objects.
+	 *
+	 * @author Nicolas Bremard
+	 * @version 1.1.7
+	 */
+	class LIBDECL TuioBlob3D : public TuioContainer {
+
+	protected:
+		/**
+		 * The individual blob ID number that is assigned to each TuioBlob3D.
+		 */
+		int blob_id;
+
+		/**
+		 * The roll angle value.
+		 */
+		float roll;
+		/**
+		 * The roll speed value.
+		 */
+		float roll_speed;
+		/**
+		 * The roll acceleration value.
+		 */
+		float roll_accel;
+		/**
+		 * The pitch angle value.
+		 */
+		float pitch;
+		/**
+		 * The pitch speed value.
+		 */
+		float pitch_speed;
+		/**
+		 * The pitch acceleration value.
+		 */
+		float pitch_accel;
+		/**
+		 * The yaw angle value.
+		 */
+		float yaw;
+		/**
+		 * The yaw speed value.
+		 */
+		float yaw_speed;
+		/**
+		 * The yaw acceleration value.
+		 */
+		float yaw_accel;
+
+		/**
+		 * The rotation acceleration value.
+		 */
+		float rotation_accel;
+
+
+		float rollThreshold, pitchThreshold, yawThreshold;
+		OneEuroFilter *rollFilter, *pitchFilter, *yawFilter;
+
+
+		/**
+		 * The width value.
+		 */
+		float width;
+		/**
+		 * The height value.
+		 */
+		float height;
+		/**
+		 * The depth value.
+		 */
+		float depth;
+
+		
+		float widthThreshold, heightThreshold, depthThreshold;
+		OneEuroFilter *widthFilter, *heightFilter, *depthFilter;
+
+
+
+		/**
+		 * The volume value.
+		 */
+		float volume;
+
+	public:
+		using TuioContainer::update;
+
+		/**
+		 * This constructor takes a TuioTime argument and assigns it along with the provided
+		 * Session ID, X and Y coordinate, width, height and angle to the newly created TuioBlob3D.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	si	the Session ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 * @param	w	the width to assign
+		 * @param	h	the height to assign
+		 * @param	d	the depth to assign
+		 * @param	v	the volume to assign
+		 */
+		TuioBlob3D(TuioTime ttime, long si, int bi, float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v);
+
+		/**
+		 * This constructor takes the provided Session ID, X and Y coordinate
+		 *  width, height and angle, and assigs these values to the newly created TuioBlob3D.
+		 *
+		 * @param	si	the Session ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 * @param	w	the width to assign
+		 * @param	h	the height to assign
+		 * @param	d	the depth to assign
+		 * @param	v	the volume to assign
+		 */
+		TuioBlob3D(long si, int bi, float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v);
+
+		/**
+		 * This constructor takes the atttibutes of the provided TuioBlob3D
+		 * and assigs these values to the newly created TuioBlob3D.
+		 *
+		 * @param	tblb	the TuioBlob3D to assign
+		 */
+		TuioBlob3D(TuioBlob3D *tblb);
+
+		/**
+		 * The destructor is doing nothing in particular.
+		 */
+		virtual ~TuioBlob3D() {
+			if (rollFilter) delete rollFilter;
+			if (pitchFilter) delete pitchFilter;
+			if (yawFilter) delete yawFilter;
+			if (widthFilter) delete widthFilter;
+			if (heightFilter) delete heightFilter;
+			if (depthFilter) delete depthFilter ;
+		};
+
+		/**
+		 * Returns the Blob ID of this TuioBlob3D.
+		 * @return	the Blob ID of this TuioBlob3D
+		 */
+		int getBlobID() const;
+
+		/**
+		 * Sets the Blob ID of this TuioBlob3D.
+		 * @param bi	the new Blob ID for this TuioBlob3D
+		 */
+		void setBlobID(int bi);
+
+		/**
+		 * Takes a TuioTime argument and assigns it along with the provided
+		 * X and Y coordinate, angle, X and Y velocity, motion acceleration,
+		 * rotation speed and rotation acceleration to the private TuioBlob3D attributes.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 * @param	w	the width to assign
+		 * @param	h	the height to assign
+		 * @param	d	the depth to assign
+		 * @param	v	the volume to assign
+		 * @param	xs	the X velocity to assign
+		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
+		 * @param	ros	the roll orientation speed to assign
+		 * @param	pos	the pitch orientation speed to assign
+		 * @param	yos	the yaw orientation speed to assign
+		 * @param	ma	the motion acceleration to assign
+		 * @param	ra	the rotation acceleration to assign
+		 */
+		void update(TuioTime ttime, float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v, float xs, float ys, float zs, float ros, float pos, float yos, float ma, float ra);
+
+		/**
+		 * Assigns the provided X and Y coordinate, angle, X and Y velocity, motion acceleration
+		 * rotation velocity and rotation acceleration to the private TuioContainer attributes.
+		 * The TuioTime time stamp remains unchanged.
+		 *
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 * @param	w	the width to assign
+		 * @param	h	the height to assign
+		 * @param	d	the depth to assign
+		 * @param	v	the volume to assign
+		 * @param	xs	the X velocity to assign
+		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
+		 * @param	ros	the roll orientation speed to assign
+		 * @param	pos	the pitch orientation speed to assign
+		 * @param	yos	the yaw orientation speed to assign
+		 * @param	ma	the motion acceleration to assign
+		 * @param	ra	the rotation acceleration to assign
+		 */
+		void update(float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v, float xs, float ys, float zs, float ros, float pos, float yos, float ma, float ra);
+
+		/**
+		 * Takes a TuioTime argument and assigns it along with the provided
+		 * X and Y coordinate and angle to the private TuioBlob3D attributes.
+		 * The speed and accleration values are calculated accordingly.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 * @param	w	the width to assign
+		 * @param	h	the height to assign
+		 * @param	d	the depth to assign
+		 * @param	v	the volume to assign
+		 */
+		void update(TuioTime ttime, float xp, float yp, float zp, float ro, float po, float yo, float w, float h, float d, float v);
+
+		/**
+		 * This method is used to calculate the speed and acceleration values of a
+		 * TuioBlob3D with unchanged position and angle.
+		 */
+		void stop(TuioTime ttime);
+
+		/**
+		 * Takes the atttibutes of the provided TuioBlob3D
+		 * and assigs these values to this TuioBlob3D.
+		 * The TuioTime time stamp of this TuioContainer remains unchanged.
+		 *
+		 * @param	tblb	the TuioContainer to assign
+		 */
+		void update(TuioBlob3D *tblb);
+
+		/**
+		 * Returns the width of this TuioBlob3D.
+		 * @return	the width of this TuioBlob3D
+		 */
+		float getWidth() const;
+
+		/**
+		 * Returns the height of this TuioBlob3D.
+		 * @return	the height of this TuioBlob3D
+		 */
+		float getHeight() const;
+
+		/**
+		 * Returns the depth of this TuioBlob3D.
+		 * @return	the depth of this TuioBlob3D
+		 */
+		float getDepth() const;
+
+		/**
+		 * Returns the width of this TuioBlob3D in real unit.
+		 * @return	the width of this TuioBlob3D
+		 */
+		int getSpaceWidth(int w) const;
+
+		/**
+		 * Returns the height of this TuioBlob3D in real unit.
+		 * @return	the height of this TuioBlob3D
+		 */
+		int getSpaceHeight(int h) const;
+
+		/**
+		 * Returns the depth of this TuioBlob3D in real unit.
+		 * @return	the depth of this TuioBlob3D
+		 */
+		int getSpaceDepth(int d) const;
+
+		/**
+		 * Returns the volume of this TuioBlob3D.
+		 * @return	the volume of this TuioBlob3D
+		 */
+		float getVolume() const;
+
+		
+
+
+		/**
+		 * Returns the roll angle of this TuioObject.
+		 * @return	the roll angle of this TuioObject
+		 */
+		float getRoll() const;
+
+		/**
+		 * Returns the roll angle in degrees of this TuioObject.
+		 * @return	the roll angle in degrees of this TuioObject
+		 */
+		float getRollDegrees() const;
+
+		/**
+		 * Returns the roll speed of this TuioObject.
+		 * @return	the roll speed of this TuioObject
+		 */
+		float getRollSpeed() const;
+
+		/**
+		 * Returns the roll accel of this TuioObject.
+		 * @return	the roll accel of this TuioObject
+		 */
+		float getRollAccel() const;
+
+		/**
+		 * Returns the pitch angle of this TuioObject.
+		 * @return	the pitch angle of this TuioObject
+		 */
+		float getPitch() const;
+
+		/**
+		 * Returns the pitch angle in degrees of this TuioObject.
+		 * @return	the pitch angle in degrees of this TuioObject
+		 */
+		float getPitchDegrees() const;
+
+		/**
+		 * Returns the pitch speed of this TuioObject.
+		 * @return	the pitch speed of this TuioObject
+		 */
+		float getPitchSpeed() const;
+
+		/**
+		 * Returns the pitch accel of this TuioObject.
+		 * @return	the pitch accel of this TuioObject
+		 */
+		float getPitchAccel() const;
+
+		/**
+		 * Returns the yaw angle of this TuioObject.
+		 * @return	the yaw angle of this TuioObject
+		 */
+		float getYaw() const;
+
+		/**
+		 * Returns the yaw angle in degrees of this TuioObject.
+		 * @return	the yaw angle in degrees of this TuioObject
+		 */
+		float getYawDegrees() const;
+
+		/**
+		 * Returns the yaw speed of this TuioObject.
+		 * @return	the yaw speed of this TuioObject
+		 */
+		float getYawSpeed() const;
+
+		/**
+		 * Returns the yaw accel of this TuioObject.
+		 * @return	the yaw accel of this TuioObject
+		 */
+		float getYawAccel() const;
+
+
+
+
+		/**
+		 * Returns the rotation acceleration of this TuioObject.
+		 * @return	the rotation acceleration of this TuioObject
+		 */
+		float getRotationAccel() const;
+
+
+
+		/**
+		 * Returns true of this TuioBlob3D is moving.
+		 * @return	true of this TuioBlob3D is moving
+		 */
+		bool isMoving() const;
+
+
+		void addRollThreshold(float thresh);
+		void addPitchThreshold(float thresh);
+		void addYawThreshold(float thresh);
+
+		void removeRollThreshold();
+		void removePitchThreshold();
+		void removeYawThreshold();
+
+		void addRollFilter(float mcut, float beta);
+		void addPitchFilter(float mcut, float beta);
+		void addYawFilter(float mcut, float beta);
+
+		void removeRollFilter();
+		void removePitchFilter();
+		void removeYawFilter();
+
+
+
+
+
+		void addWidthThreshold(float thresh);
+		void addHeightThreshold(float thresh);
+		void addDepthThreshold(float thresh);
+
+		void removeWidthThreshold();
+		void removeHeightThreshold();
+		void removeDepthThreshold();
+
+		void addWidthFilter(float mcut, float beta);
+		void addHeightFilter(float mcut, float beta);
+		void addDepthFilter(float mcut, float beta);
+
+		void removeWidthFilter();
+		void removeHeightFilter();
+		void removeDepthFilter();
+
+	};
+}
+#endif

--- a/TUIO/TuioClient.cpp
+++ b/TUIO/TuioClient.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioClient.cpp
+++ b/TUIO/TuioClient.cpp
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -60,11 +60,17 @@ void TuioClient::initialize()	{
 	receiver->addTuioClient(this);
 	maxCursorID[source_id] = -1;
 	maxBlobID[source_id]   = -1;
+	maxCursor25DID[source_id] = -1;
+	maxBlob25DID[source_id] = -1;
+	maxCursor3DID[source_id] = -1;
+	maxBlob3DID[source_id] = -1;
 }
 
 TuioClient::~TuioClient() {
 	if (local_receiver) delete receiver;
 }
+
+//TODO
 
 void TuioClient::processOSC( const ReceivedMessage& msg ) {
 	try {
@@ -235,7 +241,8 @@ void TuioClient::processOSC( const ReceivedMessage& msg ) {
 				
 				frameObjects.clear();
 			}
-		} else if( strcmp( msg.AddressPattern(), "/tuio/2Dcur" ) == 0 ) {
+		} 
+		else if( strcmp( msg.AddressPattern(), "/tuio/2Dcur" ) == 0 ) {
 			const char* cmd;
 			args >> cmd;
 			
@@ -282,7 +289,7 @@ void TuioClient::processOSC( const ReceivedMessage& msg ) {
 				} else if ( ((*tcur)->getX()!=xpos) || ((*tcur)->getY()!=ypos) || ((*tcur)->getXSpeed()!=xspeed) || ((*tcur)->getYSpeed()!=yspeed) || ((*tcur)->getMotionAccel()!=maccel) ) {
 
 					TuioCursor *updateCursor = new TuioCursor((long)s_id,(*tcur)->getCursorID(),xpos,ypos);
-					updateCursor->update(xpos,ypos,xspeed,yspeed,maccel);
+					updateCursor->update(xpos,ypos,0,xspeed,yspeed,0,maccel);
 					frameCursors.push_back(updateCursor);
 
 				}
@@ -439,9 +446,9 @@ void TuioClient::processOSC( const ReceivedMessage& msg ) {
 								}
 								
 								if ( (tcur->getX()!=frameCursor->getX() && tcur->getXSpeed()==0) || (tcur->getY()!=frameCursor->getY() && tcur->getYSpeed()==0) )
-									frameCursor->update(currentTime,tcur->getX(),tcur->getY());
+									frameCursor->update(currentTime,tcur->getX(),tcur->getY(), tcur->getZ());
 								else
-									frameCursor->update(currentTime,tcur->getX(),tcur->getY(),tcur->getXSpeed(),tcur->getYSpeed(),tcur->getMotionAccel());
+									frameCursor->update(currentTime,tcur->getX(),tcur->getY(), tcur->getZ(),tcur->getXSpeed(),tcur->getYSpeed(), tcur->getZSpeed(),tcur->getMotionAccel());
 			
 								delete tcur;
 								unlockCursorList();
@@ -464,7 +471,8 @@ void TuioClient::processOSC( const ReceivedMessage& msg ) {
 				
 				frameCursors.clear();
 			}
-		} else if( strcmp( msg.AddressPattern(), "/tuio/2Dblb" ) == 0 ){
+		} else 
+		if( strcmp( msg.AddressPattern(), "/tuio/2Dblb" ) == 0 ){
 			const char* cmd;
 			args >> cmd;
 			
@@ -692,6 +700,1320 @@ void TuioClient::processOSC( const ReceivedMessage& msg ) {
 				frameBlobs.clear();
 			}
 		}
+		else
+
+
+		//25D
+		if (strcmp(msg.AddressPattern(), "/tuio/25Dobj") == 0) {
+
+			const char* cmd;
+			args >> cmd;
+
+			if (strcmp(cmd, "source") == 0) {
+				const char* src;
+				args >> src;
+
+				source_name = strtok((char*)src, "@");
+				char *addr = strtok(NULL, "@");
+
+				if (addr != NULL) source_addr = addr;
+				else source_addr = (char*)"localhost";
+
+				// check if we know that source
+				std::string source_str(src);
+				std::map<std::string, int>::iterator iter = sourceList.find(source_str);
+
+				// add a new source
+				if (iter == sourceList.end()) {
+					source_id = (int)sourceList.size();
+					sourceList[source_str] = source_id;
+				}
+				else {
+					// use the found source_id
+					source_id = sourceList[source_str];
+				}
+
+			}
+			else if (strcmp(cmd, "set") == 0) {
+				int32 s_id, c_id;
+				float xpos, ypos,zpos, angle, xspeed, yspeed,zspeed, rspeed, maccel, raccel;
+				args >> s_id >> c_id >> xpos >> ypos >> zpos >> angle >> xspeed >> yspeed >> zspeed >> rspeed >> maccel >> raccel;
+
+				lockObject25DList();
+				std::list<TuioObject25D*>::iterator tobj;
+				for (tobj = object25DList.begin(); tobj != object25DList.end(); tobj++)
+					if ((*tobj)->getSessionID() == (long)s_id) break;
+
+				if (tobj == object25DList.end()) {
+
+					TuioObject25D *addObject = new TuioObject25D((long)s_id, (int)c_id, xpos, ypos,zpos, angle);
+					frameObjects25D.push_back(addObject);
+
+				}
+				else if (((*tobj)->getX() != xpos) || ((*tobj)->getY() != ypos) || ((*tobj)->getZ() != zpos) || ((*tobj)->getAngle() != angle) || ((*tobj)->getXSpeed() != xspeed) || ((*tobj)->getYSpeed() != yspeed) || ((*tobj)->getZSpeed() != zspeed) || ((*tobj)->getRotationSpeed() != rspeed) || ((*tobj)->getMotionAccel() != maccel) || ((*tobj)->getRotationAccel() != raccel)) {
+
+					TuioObject25D *updateObject = new TuioObject25D((long)s_id, (*tobj)->getSymbolID(), xpos, ypos,zpos, angle);
+					updateObject->update(xpos, ypos, zpos, angle, xspeed, yspeed, zspeed, rspeed, maccel, raccel);
+					frameObjects25D.push_back(updateObject);
+
+				}
+				unlockObject25DList();
+
+			}
+			else if (strcmp(cmd, "alive") == 0) {
+
+				int32 s_id;
+				aliveObject25DList.clear();
+				while (!args.Eos()) {
+					args >> s_id;
+					aliveObject25DList.push_back((long)s_id);
+				}
+
+			}
+			else if (strcmp(cmd, "fseq") == 0) {
+
+				int32 fseq;
+				args >> fseq;
+				bool lateFrame = false;
+				if (fseq > 0) {
+					if (fseq > currentFrame) currentTime = TuioTime::getSessionTime();
+					if ((fseq >= currentFrame) || ((currentFrame - fseq) > 100)) currentFrame = fseq;
+					else lateFrame = true;
+				}
+				else if ((TuioTime::getSessionTime().getTotalMilliseconds() - currentTime.getTotalMilliseconds()) > 100) {
+					currentTime = TuioTime::getSessionTime();
+				}
+
+				if (!lateFrame) {
+
+					lockObject25DList();
+					//find the removed objects first
+					for (std::list<TuioObject25D*>::iterator tobj = object25DList.begin(); tobj != object25DList.end(); tobj++) {
+						if ((*tobj)->getTuioSourceID() == source_id) {
+							std::list<long>::iterator iter = find(aliveObject25DList.begin(), aliveObject25DList.end(), (*tobj)->getSessionID());
+							if (iter == aliveObject25DList.end()) {
+								(*tobj)->remove(currentTime);
+								frameObjects25D.push_back(*tobj);
+							}
+						}
+					}
+					unlockObject25DList();
+
+					for (std::list<TuioObject25D*>::iterator iter = frameObjects25D.begin(); iter != frameObjects25D.end(); iter++) {
+						TuioObject25D *tobj = (*iter);
+
+						TuioObject25D *frameObject = NULL;
+						switch (tobj->getTuioState()) {
+						case TUIO_REMOVED:
+
+							frameObject = tobj;
+							frameObject->remove(currentTime);
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->removeTuioObject25D(frameObject);
+
+							lockObject25DList();
+							for (std::list<TuioObject25D*>::iterator delobj = object25DList.begin(); delobj != object25DList.end(); delobj++) {
+								if ((*delobj)->getSessionID() == frameObject->getSessionID()) {
+									object25DList.erase(delobj);
+									break;
+								}
+							}
+							unlockObject25DList();
+							break;
+						case TUIO_ADDED:
+
+							lockObject25DList();
+							frameObject = new TuioObject25D(currentTime, tobj->getSessionID(), tobj->getSymbolID(), tobj->getX(), tobj->getY(), tobj->getZ(), tobj->getAngle());
+							if (source_name) frameObject->setTuioSource(source_id, source_name, source_addr);
+							object25DList.push_back(frameObject);
+							unlockObject25DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->addTuioObject25D(frameObject);
+
+							break;
+						default:
+
+							lockObject25DList();
+							std::list<TuioObject25D*>::iterator iter;
+							for (iter = object25DList.begin(); iter != object25DList.end(); iter++) {
+								if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getSessionID() == tobj->getSessionID())) {
+									frameObject = (*iter);
+									break;
+								}
+							}
+
+							if (iter == object25DList.end()) {
+								unlockObject25DList();
+								break;
+							}
+
+							if ((tobj->getX() != frameObject->getX() && tobj->getXSpeed() == 0) || (tobj->getY() != frameObject->getY() && tobj->getYSpeed() == 0) || (tobj->getZ() != frameObject->getZ() && tobj->getZSpeed() == 0) || (tobj->getAngle() != frameObject->getAngle() && tobj->getRotationSpeed() == 0))
+								frameObject->update(currentTime, tobj->getX(), tobj->getY(), tobj->getZ(), tobj->getAngle());
+							else
+								frameObject->update(currentTime, tobj->getX(), tobj->getY(), tobj->getZ(), tobj->getAngle(), tobj->getXSpeed(), tobj->getYSpeed(), tobj->getZSpeed(), tobj->getRotationSpeed(), tobj->getMotionAccel(), tobj->getRotationAccel());
+
+							unlockObject25DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->updateTuioObject25D(frameObject);
+						}
+						delete tobj;
+					}
+
+					for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+						(*listener)->refresh(currentTime);
+
+				}
+				else {
+					for (std::list<TuioObject25D*>::iterator iter = frameObjects25D.begin(); iter != frameObjects25D.end(); iter++) {
+						TuioObject25D *tobj = (*iter);
+						delete tobj;
+					}
+				}
+
+				frameObjects25D.clear();
+			}
+		}
+		else if (strcmp(msg.AddressPattern(), "/tuio/25Dcur") == 0) {
+			const char* cmd;
+			args >> cmd;
+
+			if (strcmp(cmd, "source") == 0) {
+				const char* src;
+				args >> src;
+
+				source_name = strtok((char*)src, "@");
+				char *addr = strtok(NULL, "@");
+
+				if (addr != NULL) source_addr = addr;
+				else source_addr = (char*)"localhost";
+
+				// check if we know that source
+				std::string source_str(src);
+				std::map<std::string, int>::iterator iter = sourceList.find(source_str);
+
+				// add a new source
+				if (iter == sourceList.end()) {
+					source_id = (int)sourceList.size();
+					sourceList[source_str] = source_id;
+					maxCursor25DID[source_id] = -1;
+				}
+				else {
+					// use the found source_id
+					source_id = sourceList[source_str];
+				}
+
+			}
+			else if (strcmp(cmd, "set") == 0) {
+
+				int32 s_id;
+				float xpos, ypos,zpos, xspeed, yspeed,zspeed, maccel;
+				args >> s_id >> xpos >> ypos >> zpos >> xspeed >> yspeed >> zspeed >> maccel;
+
+				lockCursor25DList();
+				std::list<TuioCursor25D*>::iterator tcur;
+				for (tcur = cursor25DList.begin(); tcur != cursor25DList.end(); tcur++)
+					if (((*tcur)->getSessionID() == (long)s_id) && ((*tcur)->getTuioSourceID() == source_id)) break;
+
+				if (tcur == cursor25DList.end()) {
+
+					TuioCursor25D *addCursor = new TuioCursor25D((long)s_id, -1, xpos, ypos,zpos);
+					frameCursors25D.push_back(addCursor);
+
+				}
+				else if (((*tcur)->getX() != xpos) || ((*tcur)->getY() != ypos) || ((*tcur)->getZ() != zpos) || ((*tcur)->getXSpeed() != xspeed) || ((*tcur)->getYSpeed() != yspeed) || ((*tcur)->getZSpeed() != zspeed) || ((*tcur)->getMotionAccel() != maccel)) {
+
+					TuioCursor25D *updateCursor = new TuioCursor25D((long)s_id, (*tcur)->getCursorID(), xpos, ypos,zpos);
+					updateCursor->update(xpos, ypos, zpos, xspeed, yspeed, zpos, maccel);
+					frameCursors25D.push_back(updateCursor);
+
+				}
+				unlockCursor25DList();
+
+			}
+			else if (strcmp(cmd, "alive") == 0) {
+
+				int32 s_id;
+				aliveCursor25DList.clear();
+				while (!args.Eos()) {
+					args >> s_id;
+					aliveCursor25DList.push_back((long)s_id);
+				}
+
+			}
+			else if (strcmp(cmd, "fseq") == 0) {
+				int32 fseq;
+				args >> fseq;
+				bool lateFrame = false;
+				if (fseq > 0) {
+					if (fseq > currentFrame) currentTime = TuioTime::getSessionTime();
+					if ((fseq >= currentFrame) || ((currentFrame - fseq) > 100)) currentFrame = fseq;
+					else lateFrame = true;
+				}
+				else if ((TuioTime::getSessionTime().getTotalMilliseconds() - currentTime.getTotalMilliseconds()) > 100) {
+					currentTime = TuioTime::getSessionTime();
+				}
+
+				if (!lateFrame) {
+
+					lockCursor25DList();
+					// find the removed cursors first
+					for (std::list<TuioCursor25D*>::iterator tcur = cursor25DList.begin(); tcur != cursor25DList.end(); tcur++) {
+						if ((*tcur)->getTuioSourceID() == source_id) {
+							std::list<long>::iterator iter = find(aliveCursor25DList.begin(), aliveCursor25DList.end(), (*tcur)->getSessionID());
+
+							if (iter == aliveCursor25DList.end()) {
+								(*tcur)->remove(currentTime);
+								frameCursors25D.push_back(*tcur);
+							}
+						}
+					}
+					unlockCursor25DList();
+
+					for (std::list<TuioCursor25D*>::iterator iter = frameCursors25D.begin(); iter != frameCursors25D.end(); iter++) {
+						TuioCursor25D *tcur = (*iter);
+
+						int c_id = 0;
+						int free_size = 0;
+						TuioCursor25D *frameCursor = NULL;
+						switch (tcur->getTuioState()) {
+						case TUIO_REMOVED:
+
+							frameCursor = tcur;
+							frameCursor->remove(currentTime);
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->removeTuioCursor25D(frameCursor);
+
+							lockCursor25DList();
+							for (std::list<TuioCursor25D*>::iterator delcur = cursor25DList.begin(); delcur != cursor25DList.end(); delcur++) {
+								if (((*delcur)->getTuioSourceID() == source_id) && ((*delcur)->getSessionID() == frameCursor->getSessionID())) {
+									cursor25DList.erase(delcur);
+									break;
+								}
+							}
+
+							if (frameCursor->getCursorID() == maxCursor25DID[source_id]) {
+								maxCursor25DID[source_id] = -1;
+								delete frameCursor;
+
+								if (cursor25DList.size() > 0) {
+									std::list<TuioCursor25D*>::iterator clist;
+									for (clist = cursor25DList.begin(); clist != cursor25DList.end(); clist++) {
+										if ((*clist)->getTuioSourceID() == source_id) {
+											c_id = (*clist)->getCursorID();
+											if (c_id > maxCursor25DID[source_id]) maxCursor25DID[source_id] = c_id;
+										}
+									}
+
+									freeCursor25DBuffer.clear();
+									for (std::list<TuioCursor25D*>::iterator flist = freeCursor25DList.begin(); flist != freeCursor25DList.end(); flist++) {
+										TuioCursor25D *freeCursor = (*flist);
+										if (freeCursor->getTuioSourceID() == source_id) {
+											if (freeCursor->getCursorID() > maxCursor25DID[source_id]) delete freeCursor;
+											else freeCursor25DBuffer.push_back(freeCursor);
+										}
+										else freeCursor25DBuffer.push_back(freeCursor);
+									}
+									freeCursor25DList = freeCursor25DBuffer;
+
+								}
+								else {
+									freeCursor25DBuffer.clear();
+									for (std::list<TuioCursor25D*>::iterator flist = freeCursor25DList.begin(); flist != freeCursor25DList.end(); flist++) {
+										TuioCursor25D *freeCursor = (*flist);
+										if (freeCursor->getTuioSourceID() == source_id) delete freeCursor;
+										else freeCursor25DBuffer.push_back(freeCursor);
+									}
+									freeCursor25DList = freeCursor25DBuffer;
+
+								}
+							}
+							else if (frameCursor->getCursorID() < maxCursor25DID[source_id]) {
+								freeCursor25DList.push_back(frameCursor);
+							}
+
+							unlockCursor25DList();
+							break;
+						case TUIO_ADDED:
+
+							lockCursor25DList();
+							for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++)
+								if ((*iter)->getTuioSourceID() == source_id) c_id++;
+
+							for (std::list<TuioCursor25D*>::iterator iter = freeCursor25DList.begin(); iter != freeCursor25DList.end(); iter++)
+								if ((*iter)->getTuioSourceID() == source_id) free_size++;
+
+							if ((free_size <= maxCursor25DID[source_id]) && (free_size > 0)) {
+								std::list<TuioCursor25D*>::iterator closestCursor = freeCursor25DList.begin();
+
+								for (std::list<TuioCursor25D*>::iterator iter = freeCursor25DList.begin(); iter != freeCursor25DList.end(); iter++) {
+									if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getDistance(tcur) < (*closestCursor)->getDistance(tcur))) closestCursor = iter;
+								}
+
+								if (closestCursor != freeCursor25DList.end()) {
+									TuioCursor25D *freeCursor = (*closestCursor);
+									c_id = freeCursor->getCursorID();
+									freeCursor25DList.erase(closestCursor);
+									delete freeCursor;
+								}
+							}
+							else maxCursor25DID[source_id] = c_id;
+
+							frameCursor = new TuioCursor25D(currentTime, tcur->getSessionID(), c_id, tcur->getX(), tcur->getY(), tcur->getZ());
+							if (source_name) frameCursor->setTuioSource(source_id, source_name, source_addr);
+							cursor25DList.push_back(frameCursor);
+
+							delete tcur;
+							unlockCursor25DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->addTuioCursor25D(frameCursor);
+
+							break;
+						default:
+
+							lockCursor25DList();
+							std::list<TuioCursor25D*>::iterator iter;
+							for (iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++) {
+								if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getSessionID() == tcur->getSessionID())) {
+									frameCursor = (*iter);
+									break;
+								}
+							}
+
+							if (iter == cursor25DList.end()) {
+								unlockCursor25DList();
+								break;
+							}
+
+							if ((tcur->getX() != frameCursor->getX() && tcur->getXSpeed() == 0) || (tcur->getY() != frameCursor->getY() && tcur->getYSpeed() == 0) || (tcur->getZ() != frameCursor->getZ() && tcur->getZSpeed() == 0))
+								frameCursor->update(currentTime, tcur->getX(), tcur->getY(), tcur->getZ());
+							else
+								frameCursor->update(currentTime, tcur->getX(), tcur->getY(), tcur->getZ(), tcur->getXSpeed(), tcur->getYSpeed(), tcur->getZSpeed(), tcur->getMotionAccel());
+
+							delete tcur;
+							unlockCursor25DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->updateTuioCursor25D(frameCursor);
+
+						}
+					}
+
+					for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+						(*listener)->refresh(currentTime);
+
+				}
+				else {
+					for (std::list<TuioCursor25D*>::iterator iter = frameCursors25D.begin(); iter != frameCursors25D.end(); iter++) {
+						TuioCursor25D *tcur = (*iter);
+						delete tcur;
+					}
+				}
+
+				frameCursors25D.clear();
+			}
+		}
+		else if (strcmp(msg.AddressPattern(), "/tuio/25Dblb") == 0) {
+			const char* cmd;
+			args >> cmd;
+
+			if (strcmp(cmd, "source") == 0) {
+				const char* src;
+				args >> src;
+
+				source_name = strtok((char*)src, "@");
+				char *addr = strtok(NULL, "@");
+
+				if (addr != NULL) source_addr = addr;
+				else source_addr = (char*)"localhost";
+
+				// check if we know that source
+				std::string source_str(src);
+				std::map<std::string, int>::iterator iter = sourceList.find(source_str);
+
+				// add a new source
+				if (iter == sourceList.end()) {
+					source_id = (int)sourceList.size();
+					sourceList[source_str] = source_id;
+					maxBlob25DID[source_id] = -1;
+				}
+				else {
+					// use the found source_id
+					source_id = sourceList[source_str];
+				}
+
+			}
+			else if (strcmp(cmd, "set") == 0) {
+
+				int32 s_id;
+				float xpos, ypos,zpos, angle, width, height, area, xspeed, yspeed,zspeed, rspeed, maccel, raccel;
+				args >> s_id >> xpos >> ypos >> zpos >> angle >> width >> height >> area >> xspeed >> yspeed >> zspeed >> rspeed >> maccel >> raccel;
+
+				lockBlob25DList();
+				std::list<TuioBlob25D*>::iterator tblb;
+				for (tblb = blob25DList.begin(); tblb != blob25DList.end(); tblb++)
+					if ((*tblb)->getSessionID() == (long)s_id) break;
+
+				if (tblb == blob25DList.end()) {
+
+					TuioBlob25D *addBlob = new TuioBlob25D((long)s_id, -1, xpos, ypos,zpos, angle, width, height, area);
+					frameBlobs25D.push_back(addBlob);
+
+				}
+				else if (((*tblb)->getX() != xpos) || ((*tblb)->getY() != ypos) || ((*tblb)->getZ() != zpos) || ((*tblb)->getAngle() != angle) || ((*tblb)->getWidth() != width) || ((*tblb)->getHeight() != height) || ((*tblb)->getArea() != area) || ((*tblb)->getXSpeed() != xspeed) || ((*tblb)->getYSpeed() != yspeed) || ((*tblb)->getZSpeed() != zspeed) || ((*tblb)->getRotationSpeed() != rspeed) || ((*tblb)->getMotionAccel() != maccel)) {
+
+					TuioBlob25D *updateBlob = new TuioBlob25D((long)s_id, (*tblb)->getBlobID(), xpos, ypos,zpos, angle, width, height, area);
+					updateBlob->update(xpos, ypos,zpos, angle, width, height, area, xspeed, yspeed,zspeed, rspeed, maccel, raccel);
+					frameBlobs25D.push_back(updateBlob);
+				}
+				unlockBlob25DList();
+
+			}
+			else if (strcmp(cmd, "alive") == 0) {
+
+				int32 s_id;
+				aliveBlob25DList.clear();
+				while (!args.Eos()) {
+					args >> s_id;
+					aliveBlob25DList.push_back((long)s_id);
+				}
+
+			}
+			else if (strcmp(cmd, "fseq") == 0) {
+
+				int32 fseq;
+				args >> fseq;
+				bool lateFrame = false;
+				if (fseq > 0) {
+					if (fseq > currentFrame) currentTime = TuioTime::getSessionTime();
+					if ((fseq >= currentFrame) || ((currentFrame - fseq) > 100)) currentFrame = fseq;
+					else lateFrame = true;
+				}
+				else if ((TuioTime::getSessionTime().getTotalMilliseconds() - currentTime.getTotalMilliseconds()) > 100) {
+					currentTime = TuioTime::getSessionTime();
+				}
+
+				if (!lateFrame) {
+
+					lockBlob25DList();
+					// find the removed blobs first
+					for (std::list<TuioBlob25D*>::iterator tblb = blob25DList.begin(); tblb != blob25DList.end(); tblb++) {
+						if ((*tblb)->getTuioSourceID() == source_id) {
+							std::list<long>::iterator iter = find(aliveBlob25DList.begin(), aliveBlob25DList.end(), (*tblb)->getSessionID());
+
+							if (iter == aliveBlob25DList.end()) {
+								(*tblb)->remove(currentTime);
+								frameBlobs25D.push_back(*tblb);
+							}
+						}
+					}
+					unlockBlob25DList();
+
+					for (std::list<TuioBlob25D*>::iterator iter = frameBlobs25D.begin(); iter != frameBlobs25D.end(); iter++) {
+						TuioBlob25D *tblb = (*iter);
+
+						int b_id = 0;
+						int free_size = 0;
+						TuioBlob25D *frameBlob = NULL;
+						switch (tblb->getTuioState()) {
+						case TUIO_REMOVED:
+							frameBlob = tblb;
+							frameBlob->remove(currentTime);
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->removeTuioBlob25D(frameBlob);
+
+							lockBlob25DList();
+							for (std::list<TuioBlob25D*>::iterator delblb = blob25DList.begin(); delblb != blob25DList.end(); delblb++) {
+								if (((*delblb)->getTuioSourceID() == source_id) && ((*delblb)->getSessionID() == frameBlob->getSessionID())) {
+									blob25DList.erase(delblb);
+									break;
+								}
+							}
+
+							if (frameBlob->getBlobID() == maxBlob25DID[source_id]) {
+								maxBlob25DID[source_id] = -1;
+								delete frameBlob;
+
+								if (blob25DList.size() > 0) {
+									std::list<TuioBlob25D*>::iterator clist;
+									for (clist = blob25DList.begin(); clist != blob25DList.end(); clist++) {
+										if ((*clist)->getTuioSourceID() == source_id) {
+											b_id = (*clist)->getBlobID();
+											if (b_id > maxBlob25DID[source_id]) maxBlob25DID[source_id] = b_id;
+										}
+									}
+
+									freeBlob25DBuffer.clear();
+									for (std::list<TuioBlob25D*>::iterator flist = freeBlob25DList.begin(); flist != freeBlob25DList.end(); flist++) {
+										TuioBlob25D *freeBlob = (*flist);
+										if (freeBlob->getTuioSourceID() == source_id) {
+											if (freeBlob->getBlobID() > maxBlob25DID[source_id]) delete freeBlob;
+											else freeBlob25DBuffer.push_back(freeBlob);
+										}
+										else freeBlob25DBuffer.push_back(freeBlob);
+									}
+									freeBlob25DList = freeBlob25DBuffer;
+
+								}
+								else {
+									freeBlob25DBuffer.clear();
+									for (std::list<TuioBlob25D*>::iterator flist = freeBlob25DList.begin(); flist != freeBlob25DList.end(); flist++) {
+										TuioBlob25D *freeBlob = (*flist);
+										if (freeBlob->getTuioSourceID() == source_id) delete freeBlob;
+										else freeBlob25DBuffer.push_back(freeBlob);
+									}
+									freeBlob25DList = freeBlob25DBuffer;
+
+								}
+							}
+							else if (frameBlob->getBlobID() < maxBlob25DID[source_id]) {
+								freeBlob25DList.push_back(frameBlob);
+							}
+
+							unlockBlob25DList();
+							break;
+						case TUIO_ADDED:
+
+							lockBlob25DList();
+							for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++)
+								if ((*iter)->getTuioSourceID() == source_id) b_id++;
+
+							for (std::list<TuioBlob25D*>::iterator iter = freeBlob25DList.begin(); iter != freeBlob25DList.end(); iter++)
+								if ((*iter)->getTuioSourceID() == source_id) free_size++;
+
+							if ((free_size <= maxBlob25DID[source_id]) && (free_size > 0)) {
+								std::list<TuioBlob25D*>::iterator closestBlob = freeBlob25DList.begin();
+
+								for (std::list<TuioBlob25D*>::iterator iter = freeBlob25DList.begin(); iter != freeBlob25DList.end(); iter++) {
+									if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getDistance(tblb) < (*closestBlob)->getDistance(tblb))) closestBlob = iter;
+								}
+
+								if (closestBlob != freeBlob25DList.end()) {
+									TuioBlob25D *freeBlob = (*closestBlob);
+									b_id = freeBlob->getBlobID();
+									freeBlob25DList.erase(closestBlob);
+									delete freeBlob;
+								}
+							}
+							else maxBlob25DID[source_id] = b_id;
+
+							frameBlob = new TuioBlob25D(currentTime, tblb->getSessionID(), b_id, tblb->getX(), tblb->getY(), tblb->getZ(), tblb->getAngle(), tblb->getWidth(), tblb->getHeight(), tblb->getArea());
+							if (source_name) frameBlob->setTuioSource(source_id, source_name, source_addr);
+							blob25DList.push_back(frameBlob);
+
+							delete tblb;
+							unlockBlob25DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->addTuioBlob25D(frameBlob);
+
+							break;
+						default:
+
+							lockBlob25DList();
+							std::list<TuioBlob25D*>::iterator iter;
+							for (iter = blob25DList.begin(); iter != blob25DList.end(); iter++) {
+								if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getSessionID() == tblb->getSessionID())) {
+									frameBlob = (*iter);
+									break;
+								}
+							}
+
+							if (iter == blob25DList.end()) {
+								unlockBlob25DList();
+								break;
+							}
+
+							if ((tblb->getX() != frameBlob->getX() && tblb->getXSpeed() == 0) || (tblb->getY() != frameBlob->getY() && tblb->getYSpeed() == 0) || (tblb->getZ() != frameBlob->getZ() && tblb->getZSpeed() == 0) || (tblb->getAngle() != frameBlob->getAngle() && tblb->getRotationSpeed() == 0))
+								frameBlob->update(currentTime, tblb->getX(), tblb->getY(), tblb->getZ(), tblb->getAngle(), tblb->getWidth(), tblb->getHeight(), tblb->getArea());
+							else
+								frameBlob->update(currentTime, tblb->getX(), tblb->getY(), tblb->getZ(), tblb->getAngle(), tblb->getWidth(), tblb->getHeight(), tblb->getArea(), tblb->getXSpeed(), tblb->getYSpeed(), tblb->getZSpeed(), tblb->getRotationSpeed(), tblb->getMotionAccel(), tblb->getRotationAccel());
+
+							delete tblb;
+							unlockBlob25DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->updateTuioBlob25D(frameBlob);
+						}
+					}
+
+					for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+						(*listener)->refresh(currentTime);
+
+				}
+				else {
+					for (std::list<TuioBlob25D*>::iterator iter = frameBlobs25D.begin(); iter != frameBlobs25D.end(); iter++) {
+						TuioBlob25D *tblb = (*iter);
+						delete tblb;
+					}
+				}
+
+				frameBlobs25D.clear();
+			}
+		}
+		else
+
+		//3D
+		if (strcmp(msg.AddressPattern(), "/tuio/3Dobj") == 0) {
+
+			const char* cmd;
+			args >> cmd;
+
+			if (strcmp(cmd, "source") == 0) {
+				const char* src;
+				args >> src;
+
+				source_name = strtok((char*)src, "@");
+				char *addr = strtok(NULL, "@");
+
+				if (addr != NULL) source_addr = addr;
+				else source_addr = (char*)"localhost";
+
+				// check if we know that source
+				std::string source_str(src);
+				std::map<std::string, int>::iterator iter = sourceList.find(source_str);
+
+				// add a new source
+				if (iter == sourceList.end()) {
+					source_id = (int)sourceList.size();
+					sourceList[source_str] = source_id;
+				}
+				else {
+					// use the found source_id
+					source_id = sourceList[source_str];
+				}
+
+			}
+			else if (strcmp(cmd, "set") == 0) {
+				int32 s_id, c_id;
+				float xpos, ypos, zpos, roll, pitch, yaw, xspeed, yspeed, zspeed, rollspeed, pitchspeed, yawspeed, maccel, raccel;
+				args >> s_id >> c_id >> xpos >> ypos >> zpos >> roll >> pitch >> yaw >> xspeed >> yspeed >> zspeed >> rollspeed >> pitchspeed >> yawspeed >> maccel >> raccel;
+
+				lockObject3DList();
+				std::list<TuioObject3D*>::iterator tobj;
+				for (tobj = object3DList.begin(); tobj != object3DList.end(); tobj++)
+					if ((*tobj)->getSessionID() == (long)s_id) break;
+
+				if (tobj == object3DList.end()) {
+
+					TuioObject3D *addObject = new TuioObject3D((long)s_id, (int)c_id, xpos, ypos, zpos, roll, pitch, yaw);
+					frameObjects3D.push_back(addObject);
+
+				}
+				else if (((*tobj)->getX() != xpos) || ((*tobj)->getY() != ypos) || ((*tobj)->getZ() != zpos) || ((*tobj)->getRoll() != roll) || ((*tobj)->getPitch() != pitch) || ((*tobj)->getYaw() != yaw) || ((*tobj)->getXSpeed() != xspeed) || ((*tobj)->getYSpeed() != yspeed) || ((*tobj)->getZSpeed() != zspeed) || ((*tobj)->getRollSpeed() != rollspeed) || ((*tobj)->getPitchSpeed() != pitchspeed) || ((*tobj)->getYawSpeed() != yawspeed) || ((*tobj)->getMotionAccel() != maccel) || ((*tobj)->getRotationAccel() != raccel)) {
+
+					TuioObject3D *updateObject = new TuioObject3D((long)s_id, (*tobj)->getSymbolID(), xpos, ypos, zpos, roll, pitch, yaw);
+					updateObject->update(xpos, ypos, zpos, roll, pitch, yaw, xspeed, yspeed, zspeed, rollspeed, pitchspeed, yawspeed, maccel, raccel);
+					frameObjects3D.push_back(updateObject);
+
+				}
+				unlockObject3DList();
+
+			}
+			else if (strcmp(cmd, "alive") == 0) {
+
+				int32 s_id;
+				aliveObject3DList.clear();
+				while (!args.Eos()) {
+					args >> s_id;
+					aliveObject3DList.push_back((long)s_id);
+				}
+
+			}
+			else if (strcmp(cmd, "fseq") == 0) {
+
+				int32 fseq;
+				args >> fseq;
+				bool lateFrame = false;
+				if (fseq > 0) {
+					if (fseq > currentFrame) currentTime = TuioTime::getSessionTime();
+					if ((fseq >= currentFrame) || ((currentFrame - fseq) > 100)) currentFrame = fseq;
+					else lateFrame = true;
+				}
+				else if ((TuioTime::getSessionTime().getTotalMilliseconds() - currentTime.getTotalMilliseconds()) > 100) {
+					currentTime = TuioTime::getSessionTime();
+				}
+
+				if (!lateFrame) {
+
+					lockObject3DList();
+					//find the removed objects first
+					for (std::list<TuioObject3D*>::iterator tobj = object3DList.begin(); tobj != object3DList.end(); tobj++) {
+						if ((*tobj)->getTuioSourceID() == source_id) {
+							std::list<long>::iterator iter = find(aliveObject3DList.begin(), aliveObject3DList.end(), (*tobj)->getSessionID());
+							if (iter == aliveObject3DList.end()) {
+								(*tobj)->remove(currentTime);
+								frameObjects3D.push_back(*tobj);
+							}
+						}
+					}
+					unlockObject3DList();
+
+					for (std::list<TuioObject3D*>::iterator iter = frameObjects3D.begin(); iter != frameObjects3D.end(); iter++) {
+						TuioObject3D *tobj = (*iter);
+
+						TuioObject3D *frameObject = NULL;
+						switch (tobj->getTuioState()) {
+						case TUIO_REMOVED:
+
+							frameObject = tobj;
+							frameObject->remove(currentTime);
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->removeTuioObject3D(frameObject);
+
+							lockObject3DList();
+							for (std::list<TuioObject3D*>::iterator delobj = object3DList.begin(); delobj != object3DList.end(); delobj++) {
+								if ((*delobj)->getSessionID() == frameObject->getSessionID()) {
+									object3DList.erase(delobj);
+									break;
+								}
+							}
+							unlockObject3DList();
+							break;
+						case TUIO_ADDED:
+
+							lockObject3DList();
+							frameObject = new TuioObject3D(currentTime, tobj->getSessionID(), tobj->getSymbolID(), tobj->getX(), tobj->getY(), tobj->getZ(), tobj->getRoll(), tobj->getPitch(), tobj->getYaw());
+							if (source_name) frameObject->setTuioSource(source_id, source_name, source_addr);
+							object3DList.push_back(frameObject);
+							unlockObject3DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->addTuioObject3D(frameObject);
+
+							break;
+						default:
+
+							lockObject3DList();
+							std::list<TuioObject3D*>::iterator iter;
+							for (iter = object3DList.begin(); iter != object3DList.end(); iter++) {
+								if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getSessionID() == tobj->getSessionID())) {
+									frameObject = (*iter);
+									break;
+								}
+							}
+
+							if (iter == object3DList.end()) {
+								unlockObject3DList();
+								break;
+							}
+
+							if ((tobj->getX() != frameObject->getX() && tobj->getXSpeed() == 0) || (tobj->getY() != frameObject->getY() && tobj->getYSpeed() == 0) || (tobj->getZ() != frameObject->getZ() && tobj->getZSpeed() == 0) || (tobj->getRoll() != frameObject->getRoll() && tobj->getRollSpeed() == 0) || (tobj->getPitch() != frameObject->getPitch() && tobj->getPitchSpeed() == 0) || (tobj->getYaw() != frameObject->getYaw() && tobj->getYawSpeed() == 0))
+								frameObject->update(currentTime, tobj->getX(), tobj->getY(), tobj->getZ(), tobj->getRoll(), tobj->getPitch(), tobj->getYaw());
+							else
+								frameObject->update(currentTime, tobj->getX(), tobj->getY(), tobj->getZ(), tobj->getRoll(), tobj->getPitch(), tobj->getYaw(), tobj->getXSpeed(), tobj->getYSpeed(), tobj->getZSpeed(), tobj->getRollSpeed(), tobj->getPitchSpeed(), tobj->getYawSpeed(), tobj->getMotionAccel(), tobj->getRotationAccel());
+
+							unlockObject3DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->updateTuioObject3D(frameObject);
+						}
+						delete tobj;
+					}
+
+					for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+						(*listener)->refresh(currentTime);
+
+				}
+				else {
+					for (std::list<TuioObject3D*>::iterator iter = frameObjects3D.begin(); iter != frameObjects3D.end(); iter++) {
+						TuioObject3D *tobj = (*iter);
+						delete tobj;
+					}
+				}
+
+				frameObjects3D.clear();
+			}
+		}
+		else if (strcmp(msg.AddressPattern(), "/tuio/3Dcur") == 0) {
+			const char* cmd;
+			args >> cmd;
+
+			if (strcmp(cmd, "source") == 0) {
+				const char* src;
+				args >> src;
+
+				source_name = strtok((char*)src, "@");
+				char *addr = strtok(NULL, "@");
+
+				if (addr != NULL) source_addr = addr;
+				else source_addr = (char*)"localhost";
+
+				// check if we know that source
+				std::string source_str(src);
+				std::map<std::string, int>::iterator iter = sourceList.find(source_str);
+
+				// add a new source
+				if (iter == sourceList.end()) {
+					source_id = (int)sourceList.size();
+					sourceList[source_str] = source_id;
+					maxCursor3DID[source_id] = -1;
+				}
+				else {
+					// use the found source_id
+					source_id = sourceList[source_str];
+				}
+
+			}
+			else if (strcmp(cmd, "set") == 0) {
+
+				int32 s_id;
+				float xpos, ypos, zpos, xspeed, yspeed, zspeed, maccel;
+				args >> s_id >> xpos >> ypos >> zpos >> xspeed >> yspeed >> zspeed >> maccel;
+
+				lockCursor3DList();
+				std::list<TuioCursor3D*>::iterator tcur;
+				for (tcur = cursor3DList.begin(); tcur != cursor3DList.end(); tcur++)
+					if (((*tcur)->getSessionID() == (long)s_id) && ((*tcur)->getTuioSourceID() == source_id)) break;
+
+				if (tcur == cursor3DList.end()) {
+
+					TuioCursor3D *addCursor = new TuioCursor3D((long)s_id, -1, xpos, ypos, zpos);
+					frameCursors3D.push_back(addCursor);
+
+				}
+				else if (((*tcur)->getX() != xpos) || ((*tcur)->getY() != ypos) || ((*tcur)->getZ() != zpos) || ((*tcur)->getXSpeed() != xspeed) || ((*tcur)->getYSpeed() != yspeed) || ((*tcur)->getZSpeed() != zspeed) || ((*tcur)->getMotionAccel() != maccel)) {
+
+					TuioCursor3D *updateCursor = new TuioCursor3D((long)s_id, (*tcur)->getCursorID(), xpos, ypos, zpos);
+					updateCursor->update(xpos, ypos, zpos, xspeed, yspeed, zpos, maccel);
+					frameCursors3D.push_back(updateCursor);
+
+				}
+				unlockCursor3DList();
+
+			}
+			else if (strcmp(cmd, "alive") == 0) {
+
+				int32 s_id;
+				aliveCursor3DList.clear();
+				while (!args.Eos()) {
+					args >> s_id;
+					aliveCursor3DList.push_back((long)s_id);
+				}
+
+			}
+			else if (strcmp(cmd, "fseq") == 0) {
+				int32 fseq;
+				args >> fseq;
+				bool lateFrame = false;
+				if (fseq > 0) {
+					if (fseq > currentFrame) currentTime = TuioTime::getSessionTime();
+					if ((fseq >= currentFrame) || ((currentFrame - fseq) > 100)) currentFrame = fseq;
+					else lateFrame = true;
+				}
+				else if ((TuioTime::getSessionTime().getTotalMilliseconds() - currentTime.getTotalMilliseconds()) > 100) {
+					currentTime = TuioTime::getSessionTime();
+				}
+
+				if (!lateFrame) {
+
+					lockCursor3DList();
+					// find the removed cursors first
+					for (std::list<TuioCursor3D*>::iterator tcur = cursor3DList.begin(); tcur != cursor3DList.end(); tcur++) {
+						if ((*tcur)->getTuioSourceID() == source_id) {
+							std::list<long>::iterator iter = find(aliveCursor3DList.begin(), aliveCursor3DList.end(), (*tcur)->getSessionID());
+
+							if (iter == aliveCursor3DList.end()) {
+								(*tcur)->remove(currentTime);
+								frameCursors3D.push_back(*tcur);
+							}
+						}
+					}
+					unlockCursor3DList();
+
+					for (std::list<TuioCursor3D*>::iterator iter = frameCursors3D.begin(); iter != frameCursors3D.end(); iter++) {
+						TuioCursor3D *tcur = (*iter);
+
+						int c_id = 0;
+						int free_size = 0;
+						TuioCursor3D *frameCursor = NULL;
+						switch (tcur->getTuioState()) {
+						case TUIO_REMOVED:
+
+							frameCursor = tcur;
+							frameCursor->remove(currentTime);
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->removeTuioCursor3D(frameCursor);
+
+							lockCursor3DList();
+							for (std::list<TuioCursor3D*>::iterator delcur = cursor3DList.begin(); delcur != cursor3DList.end(); delcur++) {
+								if (((*delcur)->getTuioSourceID() == source_id) && ((*delcur)->getSessionID() == frameCursor->getSessionID())) {
+									cursor3DList.erase(delcur);
+									break;
+								}
+							}
+
+							if (frameCursor->getCursorID() == maxCursor3DID[source_id]) {
+								maxCursor3DID[source_id] = -1;
+								delete frameCursor;
+
+								if (cursor3DList.size() > 0) {
+									std::list<TuioCursor3D*>::iterator clist;
+									for (clist = cursor3DList.begin(); clist != cursor3DList.end(); clist++) {
+										if ((*clist)->getTuioSourceID() == source_id) {
+											c_id = (*clist)->getCursorID();
+											if (c_id > maxCursor3DID[source_id]) maxCursor3DID[source_id] = c_id;
+										}
+									}
+
+									freeCursor3DBuffer.clear();
+									for (std::list<TuioCursor3D*>::iterator flist = freeCursor3DList.begin(); flist != freeCursor3DList.end(); flist++) {
+										TuioCursor3D *freeCursor = (*flist);
+										if (freeCursor->getTuioSourceID() == source_id) {
+											if (freeCursor->getCursorID() > maxCursor3DID[source_id]) delete freeCursor;
+											else freeCursor3DBuffer.push_back(freeCursor);
+										}
+										else freeCursor3DBuffer.push_back(freeCursor);
+									}
+									freeCursor3DList = freeCursor3DBuffer;
+
+								}
+								else {
+									freeCursor3DBuffer.clear();
+									for (std::list<TuioCursor3D*>::iterator flist = freeCursor3DList.begin(); flist != freeCursor3DList.end(); flist++) {
+										TuioCursor3D *freeCursor = (*flist);
+										if (freeCursor->getTuioSourceID() == source_id) delete freeCursor;
+										else freeCursor3DBuffer.push_back(freeCursor);
+									}
+									freeCursor3DList = freeCursor3DBuffer;
+
+								}
+							}
+							else if (frameCursor->getCursorID() < maxCursor3DID[source_id]) {
+								freeCursor3DList.push_back(frameCursor);
+							}
+
+							unlockCursor3DList();
+							break;
+						case TUIO_ADDED:
+
+							lockCursor3DList();
+							for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++)
+								if ((*iter)->getTuioSourceID() == source_id) c_id++;
+
+							for (std::list<TuioCursor3D*>::iterator iter = freeCursor3DList.begin(); iter != freeCursor3DList.end(); iter++)
+								if ((*iter)->getTuioSourceID() == source_id) free_size++;
+
+							if ((free_size <= maxCursor3DID[source_id]) && (free_size > 0)) {
+								std::list<TuioCursor3D*>::iterator closestCursor = freeCursor3DList.begin();
+
+								for (std::list<TuioCursor3D*>::iterator iter = freeCursor3DList.begin(); iter != freeCursor3DList.end(); iter++) {
+									if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getDistance(tcur) < (*closestCursor)->getDistance(tcur))) closestCursor = iter;
+								}
+
+								if (closestCursor != freeCursor3DList.end()) {
+									TuioCursor3D *freeCursor = (*closestCursor);
+									c_id = freeCursor->getCursorID();
+									freeCursor3DList.erase(closestCursor);
+									delete freeCursor;
+								}
+							}
+							else maxCursor3DID[source_id] = c_id;
+
+							frameCursor = new TuioCursor3D(currentTime, tcur->getSessionID(), c_id, tcur->getX(), tcur->getY(), tcur->getZ());
+							if (source_name) frameCursor->setTuioSource(source_id, source_name, source_addr);
+							cursor3DList.push_back(frameCursor);
+
+							delete tcur;
+							unlockCursor3DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->addTuioCursor3D(frameCursor);
+
+							break;
+						default:
+
+							lockCursor3DList();
+							std::list<TuioCursor3D*>::iterator iter;
+							for (iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++) {
+								if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getSessionID() == tcur->getSessionID())) {
+									frameCursor = (*iter);
+									break;
+								}
+							}
+
+							if (iter == cursor3DList.end()) {
+								unlockCursor3DList();
+								break;
+							}
+
+							if ((tcur->getX() != frameCursor->getX() && tcur->getXSpeed() == 0) || (tcur->getY() != frameCursor->getY() && tcur->getYSpeed() == 0) || (tcur->getZ() != frameCursor->getZ() && tcur->getZSpeed() == 0))
+								frameCursor->update(currentTime, tcur->getX(), tcur->getY(), tcur->getZ());
+							else
+								frameCursor->update(currentTime, tcur->getX(), tcur->getY(), tcur->getZ(), tcur->getXSpeed(), tcur->getYSpeed(), tcur->getZSpeed(), tcur->getMotionAccel());
+
+							delete tcur;
+							unlockCursor3DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->updateTuioCursor3D(frameCursor);
+
+						}
+					}
+
+					for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+						(*listener)->refresh(currentTime);
+
+				}
+				else {
+					for (std::list<TuioCursor3D*>::iterator iter = frameCursors3D.begin(); iter != frameCursors3D.end(); iter++) {
+						TuioCursor3D *tcur = (*iter);
+						delete tcur;
+					}
+				}
+
+				frameCursors3D.clear();
+			}
+		}
+		else if (strcmp(msg.AddressPattern(), "/tuio/3Dblb") == 0) {
+			const char* cmd;
+			args >> cmd;
+
+			if (strcmp(cmd, "source") == 0) {
+				const char* src;
+				args >> src;
+
+				source_name = strtok((char*)src, "@");
+				char *addr = strtok(NULL, "@");
+
+				if (addr != NULL) source_addr = addr;
+				else source_addr = (char*)"localhost";
+
+				// check if we know that source
+				std::string source_str(src);
+				std::map<std::string, int>::iterator iter = sourceList.find(source_str);
+
+				// add a new source
+				if (iter == sourceList.end()) {
+					source_id = (int)sourceList.size();
+					sourceList[source_str] = source_id;
+					maxBlob3DID[source_id] = -1;
+				}
+				else {
+					// use the found source_id
+					source_id = sourceList[source_str];
+				}
+
+			}
+			else if (strcmp(cmd, "set") == 0) {
+
+				int32 s_id;
+				float xpos, ypos, zpos, roll, pitch, yaw, width, height, depth, volume, xspeed, yspeed, zspeed, rollspeed, pitchspeed, yawspeed, maccel, raccel;
+				args >> s_id >> xpos >> ypos >> zpos >> roll >> pitch >> yaw >> width >> height >> depth >> volume >> xspeed >> yspeed >> zspeed >> rollspeed >> pitchspeed >> yawspeed >> maccel >> raccel;
+
+				lockBlob3DList();
+				std::list<TuioBlob3D*>::iterator tblb;
+				for (tblb = blob3DList.begin(); tblb != blob3DList.end(); tblb++)
+					if ((*tblb)->getSessionID() == (long)s_id) break;
+
+				if (tblb == blob3DList.end()) {
+
+					TuioBlob3D *addBlob = new TuioBlob3D((long)s_id, -1, xpos, ypos, zpos, roll, pitch, yaw, width, height, depth, volume);
+					frameBlobs3D.push_back(addBlob);
+
+				}
+				else if (((*tblb)->getX() != xpos) || ((*tblb)->getY() != ypos) || ((*tblb)->getZ() != zpos) || ((*tblb)->getRoll() != roll) || ((*tblb)->getPitch() != pitch) || ((*tblb)->getYaw() != yaw) || ((*tblb)->getWidth() != width) || ((*tblb)->getHeight() != height) || ((*tblb)->getDepth() != depth) || ((*tblb)->getVolume() != volume) || ((*tblb)->getXSpeed() != xspeed) || ((*tblb)->getYSpeed() != yspeed) || ((*tblb)->getZSpeed() != zspeed) || ((*tblb)->getRollSpeed() != rollspeed) || ((*tblb)->getPitchSpeed() != pitchspeed) || ((*tblb)->getYawSpeed() != yaw) || ((*tblb)->getMotionAccel() != maccel)) {
+
+					TuioBlob3D *updateBlob = new TuioBlob3D((long)s_id, (*tblb)->getBlobID(), xpos, ypos, zpos, roll, pitch, yaw, width, height, depth, volume);
+					updateBlob->update(xpos, ypos, zpos, roll, pitch, yaw, width, height, depth, volume, xspeed, yspeed, zspeed, rollspeed, pitchspeed, yawspeed, maccel, raccel);
+					frameBlobs3D.push_back(updateBlob);
+				}
+				unlockBlob3DList();
+
+			}
+			else if (strcmp(cmd, "alive") == 0) {
+
+				int32 s_id;
+				aliveBlob3DList.clear();
+				while (!args.Eos()) {
+					args >> s_id;
+					aliveBlob3DList.push_back((long)s_id);
+				}
+
+			}
+			else if (strcmp(cmd, "fseq") == 0) {
+
+				int32 fseq;
+				args >> fseq;
+				bool lateFrame = false;
+				if (fseq > 0) {
+					if (fseq > currentFrame) currentTime = TuioTime::getSessionTime();
+					if ((fseq >= currentFrame) || ((currentFrame - fseq) > 100)) currentFrame = fseq;
+					else lateFrame = true;
+				}
+				else if ((TuioTime::getSessionTime().getTotalMilliseconds() - currentTime.getTotalMilliseconds()) > 100) {
+					currentTime = TuioTime::getSessionTime();
+				}
+
+				if (!lateFrame) {
+
+					lockBlob3DList();
+					// find the removed blobs first
+					for (std::list<TuioBlob3D*>::iterator tblb = blob3DList.begin(); tblb != blob3DList.end(); tblb++) {
+						if ((*tblb)->getTuioSourceID() == source_id) {
+							std::list<long>::iterator iter = find(aliveBlob3DList.begin(), aliveBlob3DList.end(), (*tblb)->getSessionID());
+
+							if (iter == aliveBlob3DList.end()) {
+								(*tblb)->remove(currentTime);
+								frameBlobs3D.push_back(*tblb);
+							}
+						}
+					}
+					unlockBlob3DList();
+
+					for (std::list<TuioBlob3D*>::iterator iter = frameBlobs3D.begin(); iter != frameBlobs3D.end(); iter++) {
+						TuioBlob3D *tblb = (*iter);
+
+						int b_id = 0;
+						int free_size = 0;
+						TuioBlob3D *frameBlob = NULL;
+						switch (tblb->getTuioState()) {
+						case TUIO_REMOVED:
+							frameBlob = tblb;
+							frameBlob->remove(currentTime);
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->removeTuioBlob3D(frameBlob);
+
+							lockBlob3DList();
+							for (std::list<TuioBlob3D*>::iterator delblb = blob3DList.begin(); delblb != blob3DList.end(); delblb++) {
+								if (((*delblb)->getTuioSourceID() == source_id) && ((*delblb)->getSessionID() == frameBlob->getSessionID())) {
+									blob3DList.erase(delblb);
+									break;
+								}
+							}
+
+							if (frameBlob->getBlobID() == maxBlob3DID[source_id]) {
+								maxBlob3DID[source_id] = -1;
+								delete frameBlob;
+
+								if (blob3DList.size() > 0) {
+									std::list<TuioBlob3D*>::iterator clist;
+									for (clist = blob3DList.begin(); clist != blob3DList.end(); clist++) {
+										if ((*clist)->getTuioSourceID() == source_id) {
+											b_id = (*clist)->getBlobID();
+											if (b_id > maxBlob3DID[source_id]) maxBlob3DID[source_id] = b_id;
+										}
+									}
+
+									freeBlob3DBuffer.clear();
+									for (std::list<TuioBlob3D*>::iterator flist = freeBlob3DList.begin(); flist != freeBlob3DList.end(); flist++) {
+										TuioBlob3D *freeBlob = (*flist);
+										if (freeBlob->getTuioSourceID() == source_id) {
+											if (freeBlob->getBlobID() > maxBlob3DID[source_id]) delete freeBlob;
+											else freeBlob3DBuffer.push_back(freeBlob);
+										}
+										else freeBlob3DBuffer.push_back(freeBlob);
+									}
+									freeBlob3DList = freeBlob3DBuffer;
+
+								}
+								else {
+									freeBlob3DBuffer.clear();
+									for (std::list<TuioBlob3D*>::iterator flist = freeBlob3DList.begin(); flist != freeBlob3DList.end(); flist++) {
+										TuioBlob3D *freeBlob = (*flist);
+										if (freeBlob->getTuioSourceID() == source_id) delete freeBlob;
+										else freeBlob3DBuffer.push_back(freeBlob);
+									}
+									freeBlob3DList = freeBlob3DBuffer;
+
+								}
+							}
+							else if (frameBlob->getBlobID() < maxBlob3DID[source_id]) {
+								freeBlob3DList.push_back(frameBlob);
+							}
+
+							unlockBlob3DList();
+							break;
+						case TUIO_ADDED:
+
+							lockBlob3DList();
+							for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++)
+								if ((*iter)->getTuioSourceID() == source_id) b_id++;
+
+							for (std::list<TuioBlob3D*>::iterator iter = freeBlob3DList.begin(); iter != freeBlob3DList.end(); iter++)
+								if ((*iter)->getTuioSourceID() == source_id) free_size++;
+
+							if ((free_size <= maxBlob3DID[source_id]) && (free_size > 0)) {
+								std::list<TuioBlob3D*>::iterator closestBlob = freeBlob3DList.begin();
+
+								for (std::list<TuioBlob3D*>::iterator iter = freeBlob3DList.begin(); iter != freeBlob3DList.end(); iter++) {
+									if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getDistance(tblb) < (*closestBlob)->getDistance(tblb))) closestBlob = iter;
+								}
+
+								if (closestBlob != freeBlob3DList.end()) {
+									TuioBlob3D *freeBlob = (*closestBlob);
+									b_id = freeBlob->getBlobID();
+									freeBlob3DList.erase(closestBlob);
+									delete freeBlob;
+								}
+							}
+							else maxBlob3DID[source_id] = b_id;
+
+							frameBlob = new TuioBlob3D(currentTime, tblb->getSessionID(), b_id, tblb->getX(), tblb->getY(), tblb->getZ(), tblb->getRoll(), tblb->getPitch(), tblb->getYaw(), tblb->getWidth(), tblb->getHeight(), tblb->getDepth(), tblb->getVolume());
+							if (source_name) frameBlob->setTuioSource(source_id, source_name, source_addr);
+							blob3DList.push_back(frameBlob);
+
+							delete tblb;
+							unlockBlob3DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->addTuioBlob3D(frameBlob);
+
+							break;
+						default:
+
+							lockBlob3DList();
+							std::list<TuioBlob3D*>::iterator iter;
+							for (iter = blob3DList.begin(); iter != blob3DList.end(); iter++) {
+								if (((*iter)->getTuioSourceID() == source_id) && ((*iter)->getSessionID() == tblb->getSessionID())) {
+									frameBlob = (*iter);
+									break;
+								}
+							}
+
+							if (iter == blob3DList.end()) {
+								unlockBlob3DList();
+								break;
+							}
+
+							if ((tblb->getX() != frameBlob->getX() && tblb->getXSpeed() == 0) || (tblb->getY() != frameBlob->getY() && tblb->getYSpeed() == 0) || (tblb->getZ() != frameBlob->getZ() && tblb->getZSpeed() == 0) || (tblb->getRoll() != frameBlob->getRoll() && tblb->getRollSpeed() == 0) || (tblb->getPitch() != frameBlob->getPitch() && tblb->getPitchSpeed() == 0) || (tblb->getYaw() != frameBlob->getYaw() && tblb->getYawSpeed() == 0))
+								frameBlob->update(currentTime, tblb->getX(), tblb->getY(), tblb->getZ(), tblb->getRoll(), tblb->getPitch(), tblb->getYaw(), tblb->getWidth(), tblb->getHeight(), tblb->getDepth(), tblb->getVolume());
+							else
+								frameBlob->update(currentTime, tblb->getX(), tblb->getY(), tblb->getZ(), tblb->getRoll(), tblb->getPitch(), tblb->getYaw(), tblb->getWidth(), tblb->getHeight(), tblb->getDepth(), tblb->getVolume(), tblb->getXSpeed(), tblb->getYSpeed(), tblb->getZSpeed(), tblb->getRollSpeed(), tblb->getPitchSpeed(), tblb->getYawSpeed(), tblb->getMotionAccel(), tblb->getRotationAccel());
+
+							delete tblb;
+							unlockBlob3DList();
+
+							for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+								(*listener)->updateTuioBlob3D(frameBlob);
+						}
+					}
+
+					for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+						(*listener)->refresh(currentTime);
+
+				}
+				else {
+					for (std::list<TuioBlob3D*>::iterator iter = frameBlobs3D.begin(); iter != frameBlobs3D.end(); iter++) {
+						TuioBlob3D *tblb = (*iter);
+						delete tblb;
+					}
+				}
+
+				frameBlobs3D.clear();
+			}
+		}
+
+
+
 	} catch( Exception& e ){
 		std::cerr << "error parsing TUIO message: "<< msg.AddressPattern() <<  " - " << e.what() << std::endl;
 	}
@@ -711,6 +2033,16 @@ void TuioClient::connect(bool lock) {
 	unlockCursorList();
 	unlockObjectList();
 	unlockBlobList();
+
+	unlockCursor25DList();
+	unlockObject25DList();
+	unlockBlob25DList();
+
+	unlockCursor3DList();
+	unlockObject3DList();
+	unlockBlob3DList();
+
+
 }
 
 void TuioClient::disconnect() {
@@ -740,7 +2072,69 @@ void TuioClient::disconnect() {
 	for (std::list<TuioBlob*>::iterator iter=freeBlobList.begin(); iter != freeBlobList.end(); iter++)
 		delete(*iter);
 	freeBlobList.clear();
+
+
+
+
+
+	aliveObject25DList.clear();
+	aliveCursor25DList.clear();
+	aliveBlob25DList.clear();
+
+	for (std::list<TuioObject25D*>::iterator iter = object25DList.begin(); iter != object25DList.end(); iter++)
+		delete (*iter);
+	object25DList.clear();
+
+	for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++)
+		delete (*iter);
+	cursor25DList.clear();
+
+	for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++)
+		delete (*iter);
+	blob25DList.clear();
+
+	for (std::list<TuioCursor25D*>::iterator iter = freeCursor25DList.begin(); iter != freeCursor25DList.end(); iter++)
+		delete(*iter);
+	freeCursor25DList.clear();
+
+	for (std::list<TuioBlob25D*>::iterator iter = freeBlob25DList.begin(); iter != freeBlob25DList.end(); iter++)
+		delete(*iter);
+	freeBlob25DList.clear();
+
+
+
+
+	aliveObject3DList.clear();
+	aliveCursor3DList.clear();
+	aliveBlob3DList.clear();
+
+	for (std::list<TuioObject3D*>::iterator iter = object3DList.begin(); iter != object3DList.end(); iter++)
+		delete (*iter);
+	object3DList.clear();
+
+	for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++)
+		delete (*iter);
+	cursor3DList.clear();
+
+	for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++)
+		delete (*iter);
+	blob3DList.clear();
+
+	for (std::list<TuioCursor3D*>::iterator iter = freeCursor3DList.begin(); iter != freeCursor3DList.end(); iter++)
+		delete(*iter);
+	freeCursor3DList.clear();
+
+	for (std::list<TuioBlob3D*>::iterator iter = freeBlob3DList.begin(); iter != freeBlob3DList.end(); iter++)
+		delete(*iter);
+	freeBlob3DList.clear();
+
+
+
 }
+
+
+
+
 
 
 TuioObject* TuioClient::getTuioObject(int src_id, long s_id) {
@@ -846,4 +2240,228 @@ std::list<TuioBlob> TuioClient::copyTuioBlobs(int source_id) {
 	unlockBlobList();
 	return listBuffer;
 }
+
+
+
+
+
+
+
+
+
+
+
+TuioObject25D* TuioClient::getTuioObject25D(int src_id, long s_id) {
+	lockObject25DList();
+	for (std::list<TuioObject25D*>::iterator iter = object25DList.begin(); iter != object25DList.end(); iter++) {
+		if (((*iter)->getTuioSourceID() == src_id) && ((*iter)->getSessionID() == s_id)) {
+			unlockObject25DList();
+			return (*iter);
+		}
+	}
+	unlockObject25DList();
+	return NULL;
+}
+
+TuioCursor25D* TuioClient::getTuioCursor25D(int src_id, long s_id) {
+	lockCursor25DList();
+	for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++) {
+		if (((*iter)->getTuioSourceID() == src_id) && ((*iter)->getSessionID() == s_id)) {
+			unlockCursor25DList();
+			return (*iter);
+		}
+	}
+	unlockCursor25DList();
+	return NULL;
+}
+
+TuioBlob25D* TuioClient::getTuioBlob25D(int src_id, long s_id) {
+	lockBlob25DList();
+	for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++) {
+		if (((*iter)->getTuioSourceID() == src_id) && ((*iter)->getSessionID() == s_id)) {
+			unlockBlob25DList();
+			return (*iter);
+		}
+	}
+	unlockBlob25DList();
+	return NULL;
+}
+
+
+std::list<TuioObject25D*> TuioClient::getTuioObjects25D(int source_id) {
+	lockObject25DList();
+	std::list<TuioObject25D*> listBuffer;
+	for (std::list<TuioObject25D*>::iterator iter = object25DList.begin(); iter != object25DList.end(); iter++) {
+		TuioObject25D *tobj = (*iter);
+		if (tobj->getTuioSourceID() == source_id)  listBuffer.push_back(tobj);
+	}
+	unlockObject25DList();
+	return listBuffer;
+}
+
+std::list<TuioCursor25D*> TuioClient::getTuioCursors25D(int source_id) {
+	lockCursor25DList();
+	std::list<TuioCursor25D*> listBuffer;
+	for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++) {
+		TuioCursor25D *tcur = (*iter);
+		if (tcur->getTuioSourceID() == source_id) listBuffer.push_back(tcur);
+	}
+	unlockCursor25DList();
+	return listBuffer;
+}
+
+std::list<TuioBlob25D*> TuioClient::getTuioBlobs25D(int source_id) {
+	lockBlob25DList();
+	std::list<TuioBlob25D*> listBuffer;
+	for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++) {
+		TuioBlob25D *tblb = (*iter);
+		if (tblb->getTuioSourceID() == source_id) listBuffer.push_back(tblb);
+	}
+	unlockBlob25DList();
+	return listBuffer;
+}
+
+
+std::list<TuioObject25D> TuioClient::copyTuioObjects25D(int source_id) {
+	lockObject25DList();
+	std::list<TuioObject25D> listBuffer;
+	for (std::list<TuioObject25D*>::iterator iter = object25DList.begin(); iter != object25DList.end(); iter++) {
+		TuioObject25D *tobj = (*iter);
+		if (tobj->getTuioSourceID() == source_id)  listBuffer.push_back(*tobj);
+	}
+	unlockObject25DList();
+	return listBuffer;
+}
+
+std::list<TuioCursor25D> TuioClient::copyTuioCursors25D(int source_id) {
+	lockCursor25DList();
+	std::list<TuioCursor25D> listBuffer;
+	for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++) {
+		TuioCursor25D *tcur = (*iter);
+		if (tcur->getTuioSourceID() == source_id) listBuffer.push_back(*tcur);
+	}
+	unlockCursor25DList();
+	return listBuffer;
+}
+
+std::list<TuioBlob25D> TuioClient::copyTuioBlobs25D(int source_id) {
+	lockBlob25DList();
+	std::list<TuioBlob25D> listBuffer;
+	for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++) {
+		TuioBlob25D *tblb = (*iter);
+		if (tblb->getTuioSourceID() == source_id) listBuffer.push_back(*tblb);
+	}
+	unlockBlob25DList();
+	return listBuffer;
+}
+
+
+
+
+
+TuioObject3D* TuioClient::getTuioObject3D(int src_id, long s_id) {
+	lockObject3DList();
+	for (std::list<TuioObject3D*>::iterator iter = object3DList.begin(); iter != object3DList.end(); iter++) {
+		if (((*iter)->getTuioSourceID() == src_id) && ((*iter)->getSessionID() == s_id)) {
+			unlockObject3DList();
+			return (*iter);
+		}
+	}
+	unlockObject3DList();
+	return NULL;
+}
+
+TuioCursor3D* TuioClient::getTuioCursor3D(int src_id, long s_id) {
+	lockCursor3DList();
+	for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++) {
+		if (((*iter)->getTuioSourceID() == src_id) && ((*iter)->getSessionID() == s_id)) {
+			unlockCursor3DList();
+			return (*iter);
+		}
+	}
+	unlockCursor3DList();
+	return NULL;
+}
+
+TuioBlob3D* TuioClient::getTuioBlob3D(int src_id, long s_id) {
+	lockBlob3DList();
+	for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++) {
+		if (((*iter)->getTuioSourceID() == src_id) && ((*iter)->getSessionID() == s_id)) {
+			unlockBlob3DList();
+			return (*iter);
+		}
+	}
+	unlockBlob3DList();
+	return NULL;
+}
+
+
+std::list<TuioObject3D*> TuioClient::getTuioObjects3D(int source_id) {
+	lockObject3DList();
+	std::list<TuioObject3D*> listBuffer;
+	for (std::list<TuioObject3D*>::iterator iter = object3DList.begin(); iter != object3DList.end(); iter++) {
+		TuioObject3D *tobj = (*iter);
+		if (tobj->getTuioSourceID() == source_id)  listBuffer.push_back(tobj);
+	}
+	unlockObject3DList();
+	return listBuffer;
+}
+
+std::list<TuioCursor3D*> TuioClient::getTuioCursors3D(int source_id) {
+	lockCursor3DList();
+	std::list<TuioCursor3D*> listBuffer;
+	for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++) {
+		TuioCursor3D *tcur = (*iter);
+		if (tcur->getTuioSourceID() == source_id) listBuffer.push_back(tcur);
+	}
+	unlockCursor3DList();
+	return listBuffer;
+}
+
+std::list<TuioBlob3D*> TuioClient::getTuioBlobs3D(int source_id) {
+	lockBlob3DList();
+	std::list<TuioBlob3D*> listBuffer;
+	for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++) {
+		TuioBlob3D *tblb = (*iter);
+		if (tblb->getTuioSourceID() == source_id) listBuffer.push_back(tblb);
+	}
+	unlockBlob3DList();
+	return listBuffer;
+}
+
+
+std::list<TuioObject3D> TuioClient::copyTuioObjects3D(int source_id) {
+	lockObject3DList();
+	std::list<TuioObject3D> listBuffer;
+	for (std::list<TuioObject3D*>::iterator iter = object3DList.begin(); iter != object3DList.end(); iter++) {
+		TuioObject3D *tobj = (*iter);
+		if (tobj->getTuioSourceID() == source_id)  listBuffer.push_back(*tobj);
+	}
+	unlockObject3DList();
+	return listBuffer;
+}
+
+std::list<TuioCursor3D> TuioClient::copyTuioCursors3D(int source_id) {
+	lockCursor3DList();
+	std::list<TuioCursor3D> listBuffer;
+	for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++) {
+		TuioCursor3D *tcur = (*iter);
+		if (tcur->getTuioSourceID() == source_id) listBuffer.push_back(*tcur);
+	}
+	unlockCursor3DList();
+	return listBuffer;
+}
+
+std::list<TuioBlob3D> TuioClient::copyTuioBlobs3D(int source_id) {
+	lockBlob3DList();
+	std::list<TuioBlob3D> listBuffer;
+	for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++) {
+		TuioBlob3D *tblb = (*iter);
+		if (tblb->getTuioSourceID() == source_id) listBuffer.push_back(*tblb);
+	}
+	unlockBlob3DList();
+	return listBuffer;
+}
+
+
 

--- a/TUIO/TuioClient.h
+++ b/TUIO/TuioClient.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -45,7 +46,7 @@ namespace TUIO {
 	 * </code></p>
 	 *
 	 * @author Martin Kaltenbrunner
-	 * @version 1.1.6
+	 * @version 1.1.7
 	 */ 
 	class LIBDECL TuioClient : public TuioDispatcher { 
 		

--- a/TUIO/TuioClient.h
+++ b/TUIO/TuioClient.h
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -92,6 +92,11 @@ namespace TUIO {
 		 * @return	true if this TuioClient is currently connected
 		 */
 		bool isConnected();
+
+
+
+
+
 
 		/**
 		 * Returns a List of all currently active TuioObjects
@@ -267,6 +272,384 @@ namespace TUIO {
 		 * @return  an active TuioBlob corresponding to the provided Session ID or NULL
 		 */
 		TuioBlob* getTuioBlob(int src_id, long s_id);
+
+
+
+
+
+
+
+
+
+		/**
+		 * Returns a List of all currently active TuioObjects25D
+		 *
+		 * @return  a List of TuioObjects25D
+		 */
+		std::list<TuioObject25D*> getTuioObjects25D() {
+			return TuioDispatcher::getTuioObjects25D();
+		}
+
+		/**
+		 * Returns a List of all currently active TuioObjects25D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List of TuioObjects25D
+		 */
+		std::list<TuioObject25D*> getTuioObjects25D(int source_id);
+
+		/**
+		 * Returns a List with a copy of all currently active TuioObjects25D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List with a copy of TuioObjects
+		 */
+		std::list<TuioObject25D> copyTuioObjects25D(int source_id);
+
+
+		/**
+		 * Returns a List with a copy of all currently active TuioObjects25D
+		 *
+		 * @return  a List with a copy of TuioObjects25D
+		 */
+		std::list<TuioObject25D> copyTuioObjects25D() {
+			return TuioDispatcher::copyTuioObjects25D();
+		}
+
+		/**
+		 * Returns the TuioObject25D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioObject25D
+		 *
+		 * @param  s_id  the session ID of the corresponding TuioObject25D
+		 * @return  an active TuioObject25D corresponding to the provided Session ID or NULL
+		 */
+		TuioObject25D* getTuioObject25D(long s_id) {
+			return getTuioObject25D(0, s_id);
+		};
+
+		/**
+		 * Returns the TuioObject25D corresponding to the provided Session ID
+		 * which is associated to the given Source ID
+		 * or NULL if the Session ID does not refer to an active TuioObject25D
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @param  s_id  the session ID of the corresponding TuioObject25D
+		 * @return  an active TuioObject corresponding to the provided Session ID or NULL
+		 */
+		TuioObject25D* getTuioObject25D(int src_id, long s_id);
+
+		/**
+		 * Returns a List of all currently active TuioCursors25D
+		 *
+		 * @return  a List of TuioCursors25D
+		 */
+		std::list<TuioCursor25D*> getTuioCursors25D() {
+			return TuioDispatcher::getTuioCursors25D();
+		}
+
+		/**
+		 * Returns a List of all currently active TuioCursors25D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List of TuioCursors25D
+		 */
+		std::list<TuioCursor25D*> getTuioCursors25D(int source_id);
+
+		/**
+		 * Returns a List with a copy of all currently active TuioCursors25D
+		 *
+		 * @return  a List with a copy of TuioCursors25D
+		 */
+		std::list<TuioCursor25D> copyTuioCursors25D() {
+			return TuioDispatcher::copyTuioCursors25D();
+		}
+
+		/**
+		 * Returns a List with a copy of all currently active TuioCursors25D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List with a copy of TuioCursors25D
+		 */
+		std::list<TuioCursor25D> copyTuioCursors25D(int source_id);
+
+		/**
+		 * Returns the TuioCursor25D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioCursor25D
+		 *
+		 * @param  s_id  the session ID of the corresponding TuioCursor25D
+		 * @return  an active TuioCursor25D corresponding to the provided Session ID or NULL
+		 */
+		TuioCursor25D* getTuioCursor25D(long s_id) {
+			return getTuioCursor25D(0, s_id);
+		};
+
+		/**
+		 * Returns the TuioCursor25D corresponding to the provided Session ID
+		 * which is associated to the given Source ID
+		 * or NULL if the Session ID does not refer to an active TuioCursor25D
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @param  s_id  the session ID of the corresponding TuioCursor25D
+		 * @return  an active TuioCursor25D corresponding to the provided Session ID or NULL
+		 */
+		TuioCursor25D* getTuioCursor25D(int src_id, long s_id);
+
+		/**
+		 * Returns a List of all currently active TuioBlobs25D
+		 *
+		 * @return  a List of TuioBlobs25D
+		 */
+		std::list<TuioBlob25D*> getTuioBlobs25D() {
+			return TuioDispatcher::getTuioBlobs25D();
+		}
+
+		/**
+		 * Returns a List of all currently active TuioBlobs25D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List of TuioBlobs25D
+		 */
+		std::list<TuioBlob25D*> getTuioBlobs25D(int source_id);
+
+		/**
+		 * Returns a List with a copy of all currently active TuioBlobs25D
+		 *
+		 * @return  a List with a copy of TuioBlobs25D
+		 */
+		std::list<TuioBlob25D> copyTuioBlobs25D() {
+			return TuioDispatcher::copyTuioBlobs25D();
+		}
+
+		/**
+		 * Returns a List with a copy of all currently active TuioBlobs25D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List with a copy of TuioBlobs25D
+		 */
+		std::list<TuioBlob25D> copyTuioBlobs25D(int source_id);
+
+		/**
+		 * Returns the TuioBlob25D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioBlob25D
+		 *
+		 * @param  s_id  the session ID of the corresponding TuioBlob25D
+		 * @return  an active TuioBlob25D corresponding to the provided Session ID or NULL
+		 */
+		TuioBlob25D* getTuioBlob25D(long s_id) {
+			return getTuioBlob25D(0, s_id);
+		};
+
+		/**
+		 * Returns the TuioBlob25D corresponding to the provided Session ID
+		 * which is associated to the given Source ID
+		 * or NULL if the Session ID does not refer to an active TuioBlob25D
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @param  s_id  the session ID of the corresponding TuioBlob25D
+		 * @return  an active TuioBlob25D corresponding to the provided Session ID or NULL
+		 */
+		TuioBlob25D* getTuioBlob25D(int src_id, long s_id);
+
+
+
+
+
+
+
+
+
+
+		/**
+ * Returns a List of all currently active TuioObjects3D
+ *
+ * @return  a List of TuioObjects3D
+ */
+		std::list<TuioObject3D*> getTuioObjects3D() {
+			return TuioDispatcher::getTuioObjects3D();
+		}
+
+		/**
+		 * Returns a List of all currently active TuioObjects3D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List of TuioObjects3D
+		 */
+		std::list<TuioObject3D*> getTuioObjects3D(int source_id);
+
+		/**
+		 * Returns a List with a copy of all currently active TuioObjects3D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List with a copy of TuioObjects
+		 */
+		std::list<TuioObject3D> copyTuioObjects3D(int source_id);
+
+
+		/**
+		 * Returns a List with a copy of all currently active TuioObjects3D
+		 *
+		 * @return  a List with a copy of TuioObjects3D
+		 */
+		std::list<TuioObject3D> copyTuioObjects3D() {
+			return TuioDispatcher::copyTuioObjects3D();
+		}
+
+		/**
+		 * Returns the TuioObject3D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioObject3D
+		 *
+		 * @param  s_id  the session ID of the corresponding TuioObject3D
+		 * @return  an active TuioObject3D corresponding to the provided Session ID or NULL
+		 */
+		TuioObject3D* getTuioObject3D(long s_id) {
+			return getTuioObject3D(0, s_id);
+		};
+
+		/**
+		 * Returns the TuioObject3D corresponding to the provided Session ID
+		 * which is associated to the given Source ID
+		 * or NULL if the Session ID does not refer to an active TuioObject3D
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @param  s_id  the session ID of the corresponding TuioObject3D
+		 * @return  an active TuioObject corresponding to the provided Session ID or NULL
+		 */
+		TuioObject3D* getTuioObject3D(int src_id, long s_id);
+
+		/**
+		 * Returns a List of all currently active TuioCursors3D
+		 *
+		 * @return  a List of TuioCursors3D
+		 */
+		std::list<TuioCursor3D*> getTuioCursors3D() {
+			return TuioDispatcher::getTuioCursors3D();
+		}
+
+		/**
+		 * Returns a List of all currently active TuioCursors3D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List of TuioCursors3D
+		 */
+		std::list<TuioCursor3D*> getTuioCursors3D(int source_id);
+
+		/**
+		 * Returns a List with a copy of all currently active TuioCursors3D
+		 *
+		 * @return  a List with a copy of TuioCursors3D
+		 */
+		std::list<TuioCursor3D> copyTuioCursors3D() {
+			return TuioDispatcher::copyTuioCursors3D();
+		}
+
+		/**
+		 * Returns a List with a copy of all currently active TuioCursors3D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List with a copy of TuioCursors3D
+		 */
+		std::list<TuioCursor3D> copyTuioCursors3D(int source_id);
+
+		/**
+		 * Returns the TuioCursor3D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioCursor3D
+		 *
+		 * @param  s_id  the session ID of the corresponding TuioCursor3D
+		 * @return  an active TuioCursor3D corresponding to the provided Session ID or NULL
+		 */
+		TuioCursor3D* getTuioCursor3D(long s_id) {
+			return getTuioCursor3D(0, s_id);
+		};
+
+		/**
+		 * Returns the TuioCursor3D corresponding to the provided Session ID
+		 * which is associated to the given Source ID
+		 * or NULL if the Session ID does not refer to an active TuioCursor3D
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @param  s_id  the session ID of the corresponding TuioCursor3D
+		 * @return  an active TuioCursor3D corresponding to the provided Session ID or NULL
+		 */
+		TuioCursor3D* getTuioCursor3D(int src_id, long s_id);
+
+		/**
+		 * Returns a List of all currently active TuioBlobs3D
+		 *
+		 * @return  a List of TuioBlobs3D
+		 */
+		std::list<TuioBlob3D*> getTuioBlobs3D() {
+			return TuioDispatcher::getTuioBlobs3D();
+		}
+
+		/**
+		 * Returns a List of all currently active TuioBlobs3D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List of TuioBlobs3D
+		 */
+		std::list<TuioBlob3D*> getTuioBlobs3D(int source_id);
+
+		/**
+		 * Returns a List with a copy of all currently active TuioBlobs3D
+		 *
+		 * @return  a List with a copy of TuioBlobs3D
+		 */
+		std::list<TuioBlob3D> copyTuioBlobs3D() {
+			return TuioDispatcher::copyTuioBlobs3D();
+		}
+
+		/**
+		 * Returns a List with a copy of all currently active TuioBlobs3D
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List with a copy of TuioBlobs3D
+		 */
+		std::list<TuioBlob3D> copyTuioBlobs3D(int source_id);
+
+		/**
+		 * Returns the TuioBlob3D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioBlob3D
+		 *
+		 * @param  s_id  the session ID of the corresponding TuioBlob3D
+		 * @return  an active TuioBlob3D corresponding to the provided Session ID or NULL
+		 */
+		TuioBlob3D* getTuioBlob3D(long s_id) {
+			return getTuioBlob3D(0, s_id);
+		};
+
+		/**
+		 * Returns the TuioBlob3D corresponding to the provided Session ID
+		 * which is associated to the given Source ID
+		 * or NULL if the Session ID does not refer to an active TuioBlob3D
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @param  s_id  the session ID of the corresponding TuioBlob3D
+		 * @return  an active TuioBlob3D corresponding to the provided Session ID or NULL
+		 */
+		TuioBlob3D* getTuioBlob3D(int src_id, long s_id);
+
+
+
+
+
+
+
+
+
+
+
 		
 		void processOSC( const osc::ReceivedMessage& message);
 		
@@ -279,6 +662,25 @@ namespace TUIO {
 		std::list<long> aliveCursorList;
 		std::list<TuioBlob*> frameBlobs;
 		std::list<long> aliveBlobList;
+
+
+		std::list<TuioObject25D*> frameObjects25D;
+		std::list<long> aliveObject25DList;
+		std::list<TuioCursor25D*> frameCursors25D;
+		std::list<long> aliveCursor25DList;
+		std::list<TuioBlob25D*> frameBlobs25D;
+		std::list<long> aliveBlob25DList;
+
+
+
+		std::list<TuioObject3D*> frameObjects3D;
+		std::list<long> aliveObject3DList;
+		std::list<TuioCursor3D*> frameCursors3D;
+		std::list<long> aliveCursor3DList;
+		std::list<TuioBlob3D*> frameBlobs3D;
+		std::list<long> aliveBlob3DList;
+
+
 		
 		osc::int32 currentFrame;
 		TuioTime currentTime;
@@ -288,6 +690,21 @@ namespace TUIO {
 
 		std::list<TuioBlob*> freeBlobList, freeBlobBuffer;
 		std::map<int,int> maxBlobID;
+
+
+		std::list<TuioCursor25D*> freeCursor25DList, freeCursor25DBuffer;
+		std::map<int, int> maxCursor25DID;
+
+		std::list<TuioBlob25D*> freeBlob25DList, freeBlob25DBuffer;
+		std::map<int, int> maxBlob25DID;
+
+
+		std::list<TuioCursor3D*> freeCursor3DList, freeCursor3DBuffer;
+		std::map<int, int> maxCursor3DID;
+
+		std::list<TuioBlob3D*> freeBlob3DList, freeBlob3DBuffer;
+		std::map<int, int> maxBlob3DID;
+
 		
 		std::map<std::string,int> sourceList;
 		int source_id;

--- a/TUIO/TuioContainer.cpp
+++ b/TUIO/TuioContainer.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioContainer.cpp
+++ b/TUIO/TuioContainer.cpp
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -19,7 +19,7 @@
 #include "TuioContainer.h"
 using namespace TUIO;
 
-TuioContainer::TuioContainer (TuioTime ttime, long si, float xp, float yp):TuioPoint(ttime, xp,yp)
+TuioContainer::TuioContainer (TuioTime ttime, long si, float xp, float yp, float zp):TuioPoint(ttime, xp,yp,zp)
 ,state(TUIO_ADDED)
 ,source_id(0)
 ,source_name("undefined")
@@ -28,16 +28,18 @@ TuioContainer::TuioContainer (TuioTime ttime, long si, float xp, float yp):TuioP
 	session_id = si;
 	x_speed = 0.0f;
 	y_speed = 0.0f;
+	z_speed = 0.0f;
 	motion_speed = 0.0f;
 	motion_accel = 0.0f;
 	x_accel = 0.0f;
 	y_accel = 0.0f;
-	TuioPoint p(currentTime,xpos,ypos);
+	z_accel = 0.0f;
+	TuioPoint p(currentTime,xpos,ypos,zpos);
 	path.push_back(p);
 	lastPoint = &path.back();
 }
 
-TuioContainer::TuioContainer (long si, float xp, float yp):TuioPoint(xp,yp)
+TuioContainer::TuioContainer (long si, float xp, float yp, float zp):TuioPoint(xp,yp,zp)
 ,state(TUIO_ADDED)
 ,source_id(0)
 ,source_name("undefined")
@@ -46,11 +48,13 @@ TuioContainer::TuioContainer (long si, float xp, float yp):TuioPoint(xp,yp)
 	session_id = si;
 	x_speed = 0.0f;
 	y_speed = 0.0f;
+	z_speed = 0.0f;
 	motion_speed = 0.0f;
 	motion_accel = 0.0f;
 	x_accel = 0.0f;
 	y_accel = 0.0f;
-	TuioPoint p(currentTime,xpos,ypos);
+	z_accel = 0.0f;
+	TuioPoint p(currentTime,xpos,ypos,zpos);
 	path.push_back(p);
 	lastPoint = &path.back();
 }
@@ -64,12 +68,14 @@ TuioContainer::TuioContainer (TuioContainer *tcon):TuioPoint(tcon)
 	session_id = tcon->getSessionID();
 	x_speed = 0.0f;
 	y_speed = 0.0f;
+	z_speed = 0.0f;
 	motion_speed = 0.0f;
 	motion_accel = 0.0f;
 	x_accel = 0.0f;
 	y_accel = 0.0f;
+	z_accel = 0.0f;
 	
-	TuioPoint p(currentTime,xpos,ypos);
+	TuioPoint p(currentTime,xpos,ypos,zpos);
 	path.push_back(p);
 	lastPoint = &path.back();
 }
@@ -92,27 +98,31 @@ int TuioContainer::getTuioSourceID() const{
 	return source_id;
 }
 
-void TuioContainer::update (TuioTime ttime, float xp, float yp) {
+void TuioContainer::update (TuioTime ttime, float xp, float yp, float zp) {
 	lastPoint = &path.back();
-	TuioPoint::update(ttime,xp, yp);
+	TuioPoint::update(ttime,xp, yp, zp);
 
 	TuioTime diffTime = currentTime - lastPoint->getTuioTime();
 	float dt = diffTime.getTotalMilliseconds()/1000.0f;
 	float dx = xpos - lastPoint->getX();
 	float dy = ypos - lastPoint->getY();
-	float dist = sqrt(dx*dx+dy*dy);
+	float dz = zpos - lastPoint->getZ();
+	float dist = sqrt(dx*dx+dy*dy+dz*dz);
 	float last_motion_speed = motion_speed;
 	float last_x_speed = x_speed;
 	float last_y_speed = y_speed;
+	float last_z_speed = z_speed;
 
 	x_speed = dx/dt;
 	y_speed = dy/dt;
+	z_speed = dz / dt;
 	motion_speed = dist/dt;
 	motion_accel = (motion_speed - last_motion_speed)/dt;
 	x_accel = (x_speed - last_x_speed)/dt;
 	y_accel = (y_speed - last_y_speed)/dt;
+	z_accel = (z_speed - last_z_speed) / dt;
 
-	TuioPoint p(currentTime,xpos,ypos);
+	TuioPoint p(currentTime,xpos,ypos,zpos);
 	path.push_back(p);
     if (path.size()>MAX_PATH_SIZE) path.pop_front();
 
@@ -122,21 +132,23 @@ void TuioContainer::update (TuioTime ttime, float xp, float yp) {
 }
 
 void TuioContainer::stop(TuioTime ttime) {
-	if ( state==TUIO_IDLE )update(ttime,xpos,ypos);
+	if ( state==TUIO_IDLE )update(ttime,xpos,ypos,zpos);
 	else state=TUIO_IDLE;
 }
 
-void TuioContainer::update (TuioTime ttime, float xp, float yp, float xs, float ys, float ma) {
-	TuioPoint::update(ttime,xp, yp);
+void TuioContainer::update (TuioTime ttime, float xp, float yp, float zp, float xs, float ys, float zs, float ma) {
+	TuioPoint::update(ttime,xp, yp, zs);
 	x_speed = xs;
 	y_speed = ys;
-	motion_speed = (float)sqrt(x_speed*x_speed+y_speed*y_speed);
+	z_speed = zs;
+	motion_speed = (float)sqrt(x_speed*x_speed+y_speed*y_speed+z_speed*z_speed);
 	motion_accel = ma;
 	x_accel = ma;
 	y_accel = ma;
+	z_accel = ma;
 
 	lastPoint = &path.back();
-	TuioPoint p(currentTime,xpos,ypos);
+	TuioPoint p(currentTime,xpos,ypos,zpos);
 	path.push_back(p);
     if (path.size()>MAX_PATH_SIZE) path.pop_front();
 
@@ -145,17 +157,19 @@ void TuioContainer::update (TuioTime ttime, float xp, float yp, float xs, float 
 	else state = TUIO_STOPPED;
 }
 
-void TuioContainer::update (float xp, float yp, float xs, float ys, float ma) {
-	TuioPoint::update(xp,yp);
+void TuioContainer::update (float xp, float yp, float zp, float xs, float ys, float zs, float ma) {
+	TuioPoint::update(xp,yp,zp);
 	x_speed = xs;
 	y_speed = ys;
-	motion_speed = (float)sqrt(x_speed*x_speed+y_speed*y_speed);
+	z_speed = zs;
+	motion_speed = (float)sqrt(x_speed*x_speed+y_speed*y_speed+z_speed*z_speed);
 	motion_accel = ma;
 	x_accel = ma;
 	y_accel = ma;
+	z_accel = ma;
 
 	lastPoint = &path.back();
-	TuioPoint p(currentTime,xpos,ypos);
+	TuioPoint p(currentTime,xpos,ypos,zpos);
 	path.push_back(p);
     if (path.size()>MAX_PATH_SIZE) path.pop_front();
 
@@ -168,13 +182,15 @@ void TuioContainer::update (TuioContainer *tcon) {
 	TuioPoint::update(tcon);
 	x_speed = tcon->getXSpeed();
 	y_speed =  tcon->getYSpeed();
+	z_speed = tcon->getZSpeed();
 	motion_speed =  tcon->getMotionSpeed();
 	motion_accel = tcon->getMotionAccel();
 	x_accel = motion_accel;
 	y_accel = motion_accel;
+	z_accel = motion_accel;
 
 	lastPoint = &path.back();
-	TuioPoint p(tcon->getTuioTime(),xpos,ypos);
+	TuioPoint p(tcon->getTuioTime(),xpos,ypos,zpos);
 	path.push_back(p);
     if (path.size()>MAX_PATH_SIZE) path.pop_front();
 
@@ -204,8 +220,12 @@ float TuioContainer::getYSpeed() const{
 	return y_speed;
 }
 
+float TuioContainer::getZSpeed() const {
+	return z_speed;
+}
+
 TuioPoint TuioContainer::getPosition() const{
-	TuioPoint p(xpos,ypos);
+	TuioPoint p(xpos,ypos,zpos);
 	return p;
 }
 
@@ -259,9 +279,11 @@ TuioPoint TuioContainer::predictPosition() {
 	
 	float tx = x_speed * dt;
 	float ty = y_speed * dt;
+	float tz = z_speed * dt;
 	
 	float nx = xpos+tx-tx*x_accel*dt;
 	float ny = ypos+ty-ty*y_accel*dt;
+	float nz = zpos + tz - tz * z_accel*dt;
 	
 	//if (xposFilter && yposFilter) {
 	//	nx = xposFilter->filter(nx,dt);
@@ -270,7 +292,7 @@ TuioPoint TuioContainer::predictPosition() {
 	//}
 	
 	//std::cout << nx << " " << ny << std::endl;
-	return TuioPoint(nx,ny);
+	return TuioPoint(nx,ny,nz);
 
 	
 }

--- a/TUIO/TuioContainer.h
+++ b/TUIO/TuioContainer.h
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -30,16 +30,17 @@
 #define TUIO_ROTATING 4
 #define TUIO_STOPPED 5
 #define TUIO_REMOVED 6
+#define TUIO_RESIZED 7
 
 #define MAX_PATH_SIZE 128
 
 namespace TUIO {
 	
 	/**
-	 * The abstract TuioContainer class defines common attributes that apply to both subclasses {@link TuioObject} and {@link TuioCursor}.
+	 * The abstract TuioContainer class defines common attributes that apply to subclasses {@link TuioBlob}, {@link TuioObject} and {@link TuioCursor}.
 	 *
-	 * @author Martin Kaltenbrunner
-	 * @version 1.1.6
+	 * @author Nicolas Bremard
+	 * @version 1.1.7
 	 */ 
 	class LIBDECL TuioContainer: public TuioPoint {
 		
@@ -62,6 +63,10 @@ namespace TUIO {
 		 */ 
 		float y_speed;
 		/**
+		 * The Z-axis velocity value.
+		 */
+		float z_speed;
+		/**
 		 * The motion speed value.
 		 */ 
 		float motion_speed;
@@ -71,6 +76,7 @@ namespace TUIO {
 		float motion_accel;
 		float x_accel;
 		float y_accel;
+		float z_accel;
 		/**
 		 * A List of TuioPoints containing all the previous positions of the TUIO component.
 		 */ 
@@ -103,18 +109,20 @@ namespace TUIO {
 		 * @param	si	the Session ID to assign
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 */
-		TuioContainer (TuioTime ttime, long si, float xp, float yp);
+		TuioContainer (TuioTime ttime, long si, float xp, float yp, float zp);
 
 		/**
-		 * This constructor takes the provided Session ID, X and Y coordinate 
+		 * This constructor takes the provided Session ID, X, Y and Z coordinate 
 		 * and assigs these values to the newly created TuioContainer.
 		 *
 		 * @param	si	the Session ID to assign
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 */
-		TuioContainer (long si, float xp, float yp);
+		TuioContainer (long si, float xp, float yp, float zp);
 		
 		/**
 		 * This constructor takes the atttibutes of the provided TuioContainer 
@@ -161,8 +169,9 @@ namespace TUIO {
 		 * @param	ttime	the TuioTime to assign
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 */
-		virtual void update (TuioTime ttime, float xp, float yp);
+		virtual void update (TuioTime ttime, float xp, float yp, float zp);
 		
 		/**
 		 * This method is used to calculate the speed and acceleration values of
@@ -178,11 +187,13 @@ namespace TUIO {
 		 * @param	ttime	the TuioTime to assign
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 * @param	xs	the X velocity to assign
 		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
 		 * @param	ma	the acceleration to assign
 		 */
-		virtual void update (TuioTime ttime, float xp, float yp, float xs, float ys, float ma);
+		virtual void update (TuioTime ttime, float xp, float yp, float zp, float xs, float ys, float zs, float ma);
 		
 		/**
 		 * Assigns the provided X and Y coordinate, X and Y velocity and acceleration
@@ -190,11 +201,13 @@ namespace TUIO {
 		 *
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 * @param	xs	the X velocity to assign
 		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
 		 * @param	ma	the acceleration to assign
 		 */
-		virtual void update (float xp, float yp, float xs, float ys, float ma);
+		virtual void update (float xp, float yp, float zp, float xs, float ys, float zs, float ma);
 		
 		/**
 		 * Takes the atttibutes of the provided TuioContainer 
@@ -236,6 +249,12 @@ namespace TUIO {
 		 * @return	the Y velocity of this TuioContainer
 		 */
 		virtual float getYSpeed() const;
+
+		/**
+		 * Returns the Z velocity of this TuioContainer.
+		 * @return	the Z velocity of this TuioContainer
+		 */
+		virtual float getZSpeed() const;
 		
 		/**
 		 * Returns the position of this TuioContainer.

--- a/TUIO/TuioContainer.h
+++ b/TUIO/TuioContainer.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -37,11 +38,11 @@
 namespace TUIO {
 	
 	/**
-	 * The abstract TuioContainer class defines common attributes that apply to subclasses {@link TuioBlob}, {@link TuioObject} and {@link TuioCursor}.
+	 * The abstract TuioContainer class defines common attributes that apply to both subclasses {@link TuioObject} and {@link TuioCursor}.
 	 *
-	 * @author Nicolas Bremard
+	 * @author Martin Kaltenbrunner
 	 * @version 1.1.7
-	 */ 
+	 */
 	class LIBDECL TuioContainer: public TuioPoint {
 		
 		

--- a/TUIO/TuioCursor.cpp
+++ b/TUIO/TuioCursor.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioCursor25D.cpp
+++ b/TUIO/TuioCursor25D.cpp
@@ -16,23 +16,23 @@
  License along with this library.
 */
 
-#include "TuioCursor.h"
+#include "TuioCursor25D.h"
 
 using namespace TUIO;
 
-TuioCursor::TuioCursor (TuioTime ttime, long si, int ci, float xp, float yp):TuioContainer(ttime,si,xp,yp,0) {
+TuioCursor25D::TuioCursor25D(TuioTime ttime, long si, int ci, float xp, float yp, float zp) :TuioContainer(ttime, si, xp, yp, zp) {
 	cursor_id = ci;
 }
 
-TuioCursor::TuioCursor (long si, int ci, float xp, float yp):TuioContainer(si,xp,yp,0) {
+TuioCursor25D::TuioCursor25D(long si, int ci, float xp, float yp, float zp) : TuioContainer(si, xp, yp, zp) {
 	cursor_id = ci;
 }
 
-TuioCursor::TuioCursor (TuioCursor *tcur):TuioContainer(tcur) {
+TuioCursor25D::TuioCursor25D(TuioCursor25D *tcur) : TuioContainer(tcur) {
 	cursor_id = tcur->getCursorID();
 }
 
-int TuioCursor::getCursorID() const{
+int TuioCursor25D::getCursorID() const {
 	return cursor_id;
 };
 

--- a/TUIO/TuioCursor25D.cpp
+++ b/TUIO/TuioCursor25D.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioCursor by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioCursor25D.h
+++ b/TUIO/TuioCursor25D.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioCursor by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioCursor25D.h
+++ b/TUIO/TuioCursor25D.h
@@ -1,0 +1,88 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#ifndef INCLUDED_TUIOCURSOR25D_H
+#define INCLUDED_TUIOCURSOR25D_H
+
+#include "TuioContainer.h"
+
+namespace TUIO {
+
+	/**
+	 * The TuioCursor2.5D class encapsulates /tuio/25Dcur TUIO cursors.
+	 *
+	 * @author Nicolas Bremard
+	 * @version 1.1.7
+	 */
+	class LIBDECL TuioCursor25D : public TuioContainer {
+
+	protected:
+		/**
+		 * The individual cursor ID number that is assigned to each TuioCursor.
+		 */
+		int cursor_id;
+
+	public:
+		using TuioContainer::update;
+
+		/**
+		 * This constructor takes a TuioTime argument and assigns it along with the provided
+		 * Session ID, Cursor ID, X and Y coordinate to the newly created TuioCursor.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	si	the Session ID  to assign
+		 * @param	ci	the Cursor ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 */
+		TuioCursor25D(TuioTime ttime, long si, int ci, float xp, float yp, float zp);
+
+		/**
+		 * This constructor takes the provided Session ID, Cursor ID, X and Y coordinate
+		 * and assigs these values to the newly created TuioCursor.
+		 *
+		 * @param	si	the Session ID  to assign
+		 * @param	ci	the Cursor ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 */
+		TuioCursor25D(long si, int ci, float xp, float yp, float zp);
+
+		/**
+		 * This constructor takes the atttibutes of the provided TuioCursor
+		 * and assigs these values to the newly created TuioCursor.
+		 *
+		 * @param	tcur	the TuioCursor to assign
+		 */
+		TuioCursor25D(TuioCursor25D *tcur);
+
+		/**
+		 * The destructor is doing nothing in particular.
+		 */
+		virtual ~TuioCursor25D() {};
+
+		/**
+		 * Returns the Cursor ID of this TuioCursor.
+		 * @return	the Cursor ID of this TuioCursor
+		 */
+		int getCursorID() const;
+	};
+}
+#endif // INCLUDED_TUIOCURSOR3D_H

--- a/TUIO/TuioCursor3D.cpp
+++ b/TUIO/TuioCursor3D.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioCursor by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioCursor3D.cpp
+++ b/TUIO/TuioCursor3D.cpp
@@ -16,23 +16,23 @@
  License along with this library.
 */
 
-#include "TuioCursor.h"
+#include "TuioCursor3D.h"
 
 using namespace TUIO;
 
-TuioCursor::TuioCursor (TuioTime ttime, long si, int ci, float xp, float yp):TuioContainer(ttime,si,xp,yp,0) {
+TuioCursor3D::TuioCursor3D(TuioTime ttime, long si, int ci, float xp, float yp, float zp) :TuioContainer(ttime, si, xp, yp, zp) {
 	cursor_id = ci;
 }
 
-TuioCursor::TuioCursor (long si, int ci, float xp, float yp):TuioContainer(si,xp,yp,0) {
+TuioCursor3D::TuioCursor3D(long si, int ci, float xp, float yp, float zp) : TuioContainer(si, xp, yp, zp) {
 	cursor_id = ci;
 }
 
-TuioCursor::TuioCursor (TuioCursor *tcur):TuioContainer(tcur) {
+TuioCursor3D::TuioCursor3D(TuioCursor3D *tcur) : TuioContainer(tcur) {
 	cursor_id = tcur->getCursorID();
 }
 
-int TuioCursor::getCursorID() const{
+int TuioCursor3D::getCursorID() const {
 	return cursor_id;
 };
 

--- a/TUIO/TuioCursor3D.h
+++ b/TUIO/TuioCursor3D.h
@@ -1,0 +1,89 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#ifndef INCLUDED_TUIOCURSOR3D_H
+#define INCLUDED_TUIOCURSOR3D_H
+
+#include "TuioContainer.h"
+
+namespace TUIO {
+
+	/**
+	 * The TuioCursor3D class encapsulates /tuio/3Dcur TUIO cursors.
+	 *
+	 * @author Nicolas Bremard
+	 * @version 1.1.7
+	 */
+	class LIBDECL TuioCursor3D : public TuioContainer {
+
+	protected:
+		/**
+		 * The individual cursor ID number that is assigned to each TuioCursor.
+		 */
+		int cursor_id;
+
+	public:
+		using TuioContainer::update;
+
+		/**
+		 * This constructor takes a TuioTime argument and assigns it along with the provided
+		 * Session ID, Cursor ID, X and Y coordinate to the newly created TuioCursor.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	si	the Session ID  to assign
+		 * @param	ci	the Cursor ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 */
+		TuioCursor3D(TuioTime ttime, long si, int ci, float xp, float yp, float zp);
+
+		/**
+		 * This constructor takes the provided Session ID, Cursor ID, X and Y coordinate
+		 * and assigs these values to the newly created TuioCursor.
+		 *
+		 * @param	si	the Session ID  to assign
+		 * @param	ci	the Cursor ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 */
+		TuioCursor3D(long si, int ci, float xp, float yp, float zp);
+
+		/**
+		 * This constructor takes the atttibutes of the provided TuioCursor
+		 * and assigs these values to the newly created TuioCursor.
+		 *
+		 * @param	tcur	the TuioCursor to assign
+		 */
+		TuioCursor3D(TuioCursor3D *tcur);
+
+		/**
+		 * The destructor is doing nothing in particular.
+		 */
+		virtual ~TuioCursor3D() {};
+
+		/**
+		 * Returns the Cursor ID of this TuioCursor.
+		 * @return	the Cursor ID of this TuioCursor
+		 */
+		int getCursorID() const;
+	};
+}
+#endif // INCLUDED_TUIOCURSOR3D_H
+

--- a/TUIO/TuioCursor3D.h
+++ b/TUIO/TuioCursor3D.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioCursor by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioCustom.cpp
+++ b/TUIO/TuioCustom.cpp
@@ -16,23 +16,15 @@
  License along with this library.
 */
 
-#include "TuioCursor.h"
+#include "TuioCustom.h"
 
 using namespace TUIO;
 
-TuioCursor::TuioCursor (TuioTime ttime, long si, int ci, float xp, float yp):TuioContainer(ttime,si,xp,yp,0) {
-	cursor_id = ci;
+
+TuioCustom::TuioCustom() {
+
 }
 
-TuioCursor::TuioCursor (long si, int ci, float xp, float yp):TuioContainer(si,xp,yp,0) {
-	cursor_id = ci;
+TuioCustom::TuioCustom(TuioCustom *tblb) {
+
 }
-
-TuioCursor::TuioCursor (TuioCursor *tcur):TuioContainer(tcur) {
-	cursor_id = tcur->getCursorID();
-}
-
-int TuioCursor::getCursorID() const{
-	return cursor_id;
-};
-

--- a/TUIO/TuioCustom.h
+++ b/TUIO/TuioCustom.h
@@ -1,0 +1,73 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#ifndef INCLUDED_TUIOCUSTOM_H
+#define INCLUDED_TUIOCUSTOM_H
+
+
+#include "TuioContainer.h"
+
+namespace TUIO {
+
+	/**
+	 * The TuioCustom class encapsulates /tuio/ TUIO custom messages.
+	 *
+	 * @author Nicolas Bremard
+	 * @version 1.1.7
+	 */
+	class LIBDECL TuioCustom {
+
+
+	public:
+
+
+
+		/**
+		 * This constructor takes the provided Session ID, X and Y coordinate
+		 *  width, height and angle, and assigs these values to the newly created TuioBlob.
+		 *
+		 * @param	si	the Session ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	a	the angle to assign
+		 * @param	w	the width to assign
+		 * @param	h	the height to assign
+		 * @param	f	the area to assign
+		 */
+		TuioCustom();
+
+		/**
+		 * This constructor takes the atttibutes of the provided TuioBlob
+		 * and assigs these values to the newly created TuioBlob.
+		 *
+		 * @param	tblb	the TuioBlob to assign
+		 */
+		TuioCustom(TuioCustom *tblb);
+
+		/**
+		 * The destructor is doing nothing in particular.
+		 */
+	    ~TuioCustom() {};
+
+
+
+
+	
+	};
+}
+#endif

--- a/TUIO/TuioDispatcher.cpp
+++ b/TUIO/TuioDispatcher.cpp
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -27,13 +27,25 @@ using namespace TUIO;
 
 TuioDispatcher::TuioDispatcher() {
 #ifdef WIN32
-	cursorMutex = CreateMutex(NULL,FALSE,TEXT("cursorMutex"));
-	objectMutex = CreateMutex(NULL,FALSE,TEXT("objectMutex"));
-	blobMutex = CreateMutex(NULL,FALSE,TEXT("blobMutex"));
+	cursorMutex = CreateMutex(NULL, FALSE, TEXT("cursorMutex"));
+	objectMutex = CreateMutex(NULL, FALSE, TEXT("objectMutex"));
+	blobMutex = CreateMutex(NULL, FALSE, TEXT("blobMutex"));
+	cursor25DMutex = CreateMutex(NULL, FALSE, TEXT("cursor25DMutex"));
+	object25DMutex = CreateMutex(NULL, FALSE, TEXT("object25DMutex"));
+	blob25DMutex = CreateMutex(NULL, FALSE, TEXT("blob25DMutex"));
+	cursor3DMutex = CreateMutex(NULL, FALSE, TEXT("cursor3DMutex"));
+	object3DMutex = CreateMutex(NULL, FALSE, TEXT("object3DMutex"));
+	blob3DMutex = CreateMutex(NULL, FALSE, TEXT("blob3DMutex"));
 #else
-	pthread_mutex_init(&cursorMutex,NULL);
-	pthread_mutex_init(&objectMutex,NULL);
-	pthread_mutex_init(&blobMutex,NULL);
+	pthread_mutex_init(&cursorMutex, NULL);
+	pthread_mutex_init(&objectMutex, NULL);
+	pthread_mutex_init(&blobMutex, NULL);
+	pthread_mutex_init(&cursor25DMutex, NULL);
+	pthread_mutex_init(&object25DMutex, NULL);
+	pthread_mutex_init(&blob25DMutex, NULL);
+	pthread_mutex_init(&cursor3DMutex, NULL);
+	pthread_mutex_init(&object3DMutex, NULL);
+	pthread_mutex_init(&blob3DMutex, NULL);
 
 #endif
 }
@@ -43,10 +55,22 @@ TuioDispatcher::~TuioDispatcher() {
 	CloseHandle(cursorMutex);
 	CloseHandle(objectMutex);
 	CloseHandle(blobMutex);
+	CloseHandle(cursor25DMutex);
+	CloseHandle(object25DMutex);
+	CloseHandle(blob25DMutex);
+	CloseHandle(cursor3DMutex);
+	CloseHandle(object3DMutex);
+	CloseHandle(blob3DMutex);
 #else
 	pthread_mutex_destroy(&cursorMutex);
 	pthread_mutex_destroy(&objectMutex);
 	pthread_mutex_destroy(&blobMutex);
+	pthread_mutex_destroy(&cursor25DMutex);
+	pthread_mutex_destroy(&object25DMutex);
+	pthread_mutex_destroy(&blob25DMutex);
+	pthread_mutex_destroy(&cursor3DMutex);
+	pthread_mutex_destroy(&object3DMutex);
+	pthread_mutex_destroy(&blob3DMutex);
 #endif
 }
 
@@ -221,4 +245,327 @@ std::list<TuioBlob> TuioDispatcher::copyTuioBlobs() {
 }
 
 
+
+
+
+
+void TuioDispatcher::lockObject25DList() {
+#ifdef WIN32
+	WaitForSingleObject(object25DMutex, INFINITE);
+#else
+	pthread_mutex_lock(&object25DMutex);
+#endif
+}
+
+void TuioDispatcher::unlockObject25DList() {
+#ifdef WIN32
+	ReleaseMutex(object25DMutex);
+#else
+	pthread_mutex_unlock(&object25DMutex);
+#endif
+}
+
+void TuioDispatcher::lockCursor25DList() {
+#ifdef WIN32
+	WaitForSingleObject(cursor25DMutex, INFINITE);
+#else
+	pthread_mutex_lock(&cursorMutex25D);
+#endif
+}
+
+void TuioDispatcher::unlockCursor25DList() {
+#ifdef WIN32
+	ReleaseMutex(cursor25DMutex);
+#else
+	pthread_mutex_unlock(&cursor25DMutex);
+#endif
+}
+
+void TuioDispatcher::lockBlob25DList() {
+#ifdef WIN32
+	WaitForSingleObject(blob25DMutex, INFINITE);
+#else
+	pthread_mutex_lock(&blob25DMutex);
+#endif
+}
+
+void TuioDispatcher::unlockBlob25DList() {
+#ifdef WIN32
+	ReleaseMutex(blob25DMutex);
+#else
+	pthread_mutex_unlock(&blob25DMutex);
+#endif
+}
+
+TuioObject25D* TuioDispatcher::getTuioObject25D(long s_id) {
+	lockObject25DList();
+	for (std::list<TuioObject25D*>::iterator iter = object25DList.begin(); iter != object25DList.end(); iter++) {
+		if ((*iter)->getSessionID() == s_id) {
+			unlockObject25DList();
+			return (*iter);
+		}
+	}
+	unlockObject25DList();
+	return NULL;
+}
+
+TuioCursor25D* TuioDispatcher::getTuioCursor25D(long s_id) {
+	lockCursor25DList();
+	for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++) {
+		if ((*iter)->getSessionID() == s_id) {
+			unlockCursor25DList();
+			return (*iter);
+		}
+	}
+	unlockCursor25DList();
+	return NULL;
+}
+
+TuioBlob25D* TuioDispatcher::getTuioBlob25D(long s_id) {
+	lockBlob25DList();
+	for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++) {
+		if ((*iter)->getSessionID() == s_id) {
+			unlockBlob25DList();
+			return (*iter);
+		}
+	}
+	unlockBlob25DList();
+	return NULL;
+}
+
+std::list<TuioObject25D*> TuioDispatcher::getTuioObjects25D() {
+	lockObject25DList();
+	std::list<TuioObject25D*> listBuffer;
+	listBuffer.insert(listBuffer.end(), object25DList.begin(), object25DList.end());
+	//std::list<TuioObject25D*> listBuffer = objectList;
+	unlockObject25DList();
+	return listBuffer;
+}
+
+std::list<TuioCursor25D*> TuioDispatcher::getTuioCursors25D() {
+	lockCursor25DList();
+	std::list<TuioCursor25D*> listBuffer;
+	listBuffer.insert(listBuffer.end(), cursor25DList.begin(), cursor25DList.end());
+	//std::list<TuioCursor25D*> listBuffer = cursorList;
+	unlockCursor25DList();
+	return listBuffer;
+}
+
+std::list<TuioBlob25D*> TuioDispatcher::getTuioBlobs25D() {
+	lockBlob25DList();
+	std::list<TuioBlob25D*> listBuffer;
+	listBuffer.insert(listBuffer.end(), blob25DList.begin(), blob25DList.end());
+	//std::list<TuioBlob25D*> listBuffer = blobList;
+	unlockBlob25DList();
+	return listBuffer;
+}
+
+int TuioDispatcher::getTuioObject25DCount() {
+	return object25DList.size();
+}
+
+int TuioDispatcher::getTuioCursor25DCount() {
+	return cursor25DList.size();
+}
+
+int TuioDispatcher::getTuioBlob25DCount() {
+	return blob25DList.size();
+}
+
+std::list<TuioObject25D> TuioDispatcher::copyTuioObjects25D() {
+	lockObject25DList();
+	std::list<TuioObject25D> listBuffer;
+	for (std::list<TuioObject25D*>::iterator iter = object25DList.begin(); iter != object25DList.end(); iter++) {
+		TuioObject25D *tobj = (*iter);
+		listBuffer.push_back(*tobj);
+	}
+	unlockObject25DList();
+	return listBuffer;
+}
+
+std::list<TuioCursor25D> TuioDispatcher::copyTuioCursors25D() {
+	lockCursor25DList();
+	std::list<TuioCursor25D> listBuffer;
+	for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++) {
+		TuioCursor25D *tcur = (*iter);
+		listBuffer.push_back(*tcur);
+	}
+	unlockCursor25DList();
+
+	return listBuffer;
+}
+
+std::list<TuioBlob25D> TuioDispatcher::copyTuioBlobs25D() {
+	lockBlob25DList();
+	std::list<TuioBlob25D> listBuffer;
+	for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++) {
+		TuioBlob25D *tblb = (*iter);
+		listBuffer.push_back(*tblb);
+	}
+	unlockBlob25DList();
+	return listBuffer;
+}
+
+
+
+
+
+
+
+void TuioDispatcher::lockObject3DList() {
+#ifdef WIN32
+	WaitForSingleObject(object3DMutex, INFINITE);
+#else
+	pthread_mutex_lock(&object3DMutex);
+#endif
+}
+
+void TuioDispatcher::unlockObject3DList() {
+#ifdef WIN32
+	ReleaseMutex(object3DMutex);
+#else
+	pthread_mutex_unlock(&object3DMutex);
+#endif
+}
+
+void TuioDispatcher::lockCursor3DList() {
+#ifdef WIN32
+	WaitForSingleObject(cursor3DMutex, INFINITE);
+#else
+	pthread_mutex_lock(&cursorMutex3D);
+#endif
+}
+
+void TuioDispatcher::unlockCursor3DList() {
+#ifdef WIN32
+	ReleaseMutex(cursor3DMutex);
+#else
+	pthread_mutex_unlock(&cursor3DMutex);
+#endif
+}
+
+void TuioDispatcher::lockBlob3DList() {
+#ifdef WIN32
+	WaitForSingleObject(blob3DMutex, INFINITE);
+#else
+	pthread_mutex_lock(&blob3DMutex);
+#endif
+}
+
+void TuioDispatcher::unlockBlob3DList() {
+#ifdef WIN32
+	ReleaseMutex(blob3DMutex);
+#else
+	pthread_mutex_unlock(&blob3DMutex);
+#endif
+}
+
+TuioObject3D* TuioDispatcher::getTuioObject3D(long s_id) {
+	lockObject3DList();
+	for (std::list<TuioObject3D*>::iterator iter = object3DList.begin(); iter != object3DList.end(); iter++) {
+		if ((*iter)->getSessionID() == s_id) {
+			unlockObject3DList();
+			return (*iter);
+		}
+	}
+	unlockObject3DList();
+	return NULL;
+}
+
+TuioCursor3D* TuioDispatcher::getTuioCursor3D(long s_id) {
+	lockCursor3DList();
+	for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++) {
+		if ((*iter)->getSessionID() == s_id) {
+			unlockCursor3DList();
+			return (*iter);
+		}
+	}
+	unlockCursor3DList();
+	return NULL;
+}
+
+TuioBlob3D* TuioDispatcher::getTuioBlob3D(long s_id) {
+	lockBlob3DList();
+	for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++) {
+		if ((*iter)->getSessionID() == s_id) {
+			unlockBlob3DList();
+			return (*iter);
+		}
+	}
+	unlockBlob3DList();
+	return NULL;
+}
+
+std::list<TuioObject3D*> TuioDispatcher::getTuioObjects3D() {
+	lockObject3DList();
+	std::list<TuioObject3D*> listBuffer;
+	listBuffer.insert(listBuffer.end(), object3DList.begin(), object3DList.end());
+	//std::list<TuioObject3D*> listBuffer = objectList;
+	unlockObject3DList();
+	return listBuffer;
+}
+
+std::list<TuioCursor3D*> TuioDispatcher::getTuioCursors3D() {
+	lockCursor3DList();
+	std::list<TuioCursor3D*> listBuffer;
+	listBuffer.insert(listBuffer.end(), cursor3DList.begin(), cursor3DList.end());
+	//std::list<TuioCursor3D*> listBuffer = cursorList;
+	unlockCursor3DList();
+	return listBuffer;
+}
+
+std::list<TuioBlob3D*> TuioDispatcher::getTuioBlobs3D() {
+	lockBlob3DList();
+	std::list<TuioBlob3D*> listBuffer;
+	listBuffer.insert(listBuffer.end(), blob3DList.begin(), blob3DList.end());
+	//std::list<TuioBlob3D*> listBuffer = blobList;
+	unlockBlob3DList();
+	return listBuffer;
+}
+
+int TuioDispatcher::getTuioObject3DCount() {
+	return object3DList.size();
+}
+
+int TuioDispatcher::getTuioCursor3DCount() {
+	return cursor3DList.size();
+}
+
+int TuioDispatcher::getTuioBlob3DCount() {
+	return blob3DList.size();
+}
+
+std::list<TuioObject3D> TuioDispatcher::copyTuioObjects3D() {
+	lockObject3DList();
+	std::list<TuioObject3D> listBuffer;
+	for (std::list<TuioObject3D*>::iterator iter = object3DList.begin(); iter != object3DList.end(); iter++) {
+		TuioObject3D *tobj = (*iter);
+		listBuffer.push_back(*tobj);
+	}
+	unlockObject3DList();
+	return listBuffer;
+}
+
+std::list<TuioCursor3D> TuioDispatcher::copyTuioCursors3D() {
+	lockCursor3DList();
+	std::list<TuioCursor3D> listBuffer;
+	for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++) {
+		TuioCursor3D *tcur = (*iter);
+		listBuffer.push_back(*tcur);
+	}
+	unlockCursor3DList();
+
+	return listBuffer;
+}
+
+std::list<TuioBlob3D> TuioDispatcher::copyTuioBlobs3D() {
+	lockBlob3DList();
+	std::list<TuioBlob3D> listBuffer;
+	for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++) {
+		TuioBlob3D *tblb = (*iter);
+		listBuffer.push_back(*tblb);
+	}
+	unlockBlob3DList();
+	return listBuffer;
+}
 

--- a/TUIO/TuioDispatcher.cpp
+++ b/TUIO/TuioDispatcher.cpp
@@ -1,6 +1,8 @@
+
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -15,6 +17,7 @@
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
+
 
 #include "TuioDispatcher.h"
 

--- a/TUIO/TuioDispatcher.h
+++ b/TUIO/TuioDispatcher.h
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -69,6 +69,7 @@ namespace TUIO {
 		 */
 		void removeAllTuioListeners();
 		
+#pragma region 2D
 		/**
 		 * Returns a List of all currently active TuioObjects
 		 *
@@ -185,22 +186,284 @@ namespace TUIO {
 		 * Releases the lock of the TuioBlob list
 		 */
 		void unlockBlobList();
-		
+#pragma endregion 
+
+#pragma region 2.5D
+		/**
+		 * Returns a List of all currently active TuioObjects25D
+		 *
+		 * @return  a List of all currently active TuioObjects25D
+		 */
+		std::list<TuioObject25D*> getTuioObjects25D();
+
+		/**
+		* Returns the number of all currently active TuioObjects25D
+		*
+		* @return  the of all currently active TuioObjects25D
+		*/
+		int getTuioObject25DCount();
+
+		/**
+		 * Returns a List with a copy of currently active TuioObjects25D
+		 *
+		 * @return  a List with a copy of all currently active TuioObjects25D
+		 */
+		std::list<TuioObject25D> copyTuioObjects25D();
+
+		/**
+		 * Returns a List of all currently active TuioCursors25D
+		 *
+		 * @return  a List of all currently active TuioCursors25D
+		 */
+		std::list<TuioCursor25D*> getTuioCursors25D();
+
+		/**
+		* Returns the number of all currently active TuioCursors25D
+		*
+		* @return  the of all currently active TuioCursors25D
+		*/
+		int getTuioCursor25DCount();
+
+		/**
+		 * Returns a List with a copy of currently active TuioCursors25D
+		 *
+		 * @return  a List with a copy of all currently active TuioCursors25D
+		 */
+		std::list<TuioCursor25D> copyTuioCursors25D();
+
+		/**
+		 * Returns a List of all currently active TuioBlobs25D
+		 *
+		 * @return  a List of all currently active TuioBlobs25D
+		 */
+		std::list<TuioBlob25D*> getTuioBlobs25D();
+
+		/**
+		* Returns the number of all currently active TuioBlobs25D
+		*
+		* @return  the of all currently active TuioBlobs25D
+		*/
+		int getTuioBlob25DCount();
+
+		/**
+		 * Returns a List with a copy of currently active TuioBlobs25D
+		 *
+		 * @return  a List with a copy of all currently active TuioBlobs25D
+		 */
+		std::list<TuioBlob25D> copyTuioBlobs25D();
+
+		/**
+		 * Returns the TuioObject corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioObject
+		 *
+		 * @return  an active TuioObject corresponding to the provided Session ID or NULL
+		 */
+		TuioObject25D* getTuioObject25D(long s_id);
+
+		/**
+		 * Returns the TuioCursor25D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioCursor25D
+		 *
+		 * @return  an active TuioCursor25D corresponding to the provided Session ID or NULL
+		 */
+		TuioCursor25D* getTuioCursor25D(long s_id);
+
+		/**
+		 * Returns the TuioBlob25D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioBlob25D
+		 *
+		 * @return  an active TuioBlob25D corresponding to the provided Session ID or NULL
+		 */
+		TuioBlob25D* getTuioBlob25D(long s_id);
+
+		/**
+		 * Locks the TuioObject25D list in order to avoid updates during access
+		 */
+		void lockObject25DList();
+
+		/**
+		 * Releases the lock of the TuioObject list
+		 */
+		void unlockObject25DList();
+
+		/**
+		 * Locks the TuioCursor25D list in order to avoid updates during access
+		 */
+		void lockCursor25DList();
+
+		/**
+		 * Releases the lock of the TuioCursor25D list
+		 */
+		void unlockCursor25DList();
+
+		/**
+		 * Locks the TuioBlob25D list in order to avoid updates during access
+		 */
+		void lockBlob25DList();
+
+		/**
+		 * Releases the lock of the TuioBlob25D list
+		 */
+		void unlockBlob25DList();
+#pragma endregion 
+
+
+#pragma region 3D
+		/**
+		 * Returns a List of all currently active TuioObjects3D
+		 *
+		 * @return  a List of all currently active TuioObjects3D
+		 */
+		std::list<TuioObject3D*> getTuioObjects3D();
+
+		/**
+		* Returns the number of all currently active TuioObjects3D
+		*
+		* @return  the of all currently active TuioObjects3D
+		*/
+		int getTuioObject3DCount();
+
+		/**
+		 * Returns a List with a copy of currently active TuioObjects3D
+		 *
+		 * @return  a List with a copy of all currently active TuioObjects3D
+		 */
+		std::list<TuioObject3D> copyTuioObjects3D();
+
+		/**
+		 * Returns a List of all currently active TuioCursors3D
+		 *
+		 * @return  a List of all currently active TuioCursors3D
+		 */
+		std::list<TuioCursor3D*> getTuioCursors3D();
+
+		/**
+		* Returns the number of all currently active TuioCursors3D
+		*
+		* @return  the of all currently active TuioCursors3D
+		*/
+		int getTuioCursor3DCount();
+
+		/**
+		 * Returns a List with a copy of currently active TuioCursors3D
+		 *
+		 * @return  a List with a copy of all currently active TuioCursors3D
+		 */
+		std::list<TuioCursor3D> copyTuioCursors3D();
+
+		/**
+		 * Returns a List of all currently active TuioBlobs3D
+		 *
+		 * @return  a List of all currently active TuioBlobs3D
+		 */
+		std::list<TuioBlob3D*> getTuioBlobs3D();
+
+		/**
+		* Returns the number of all currently active TuioBlobs3D
+		*
+		* @return  the of all currently active TuioBlobs3D
+		*/
+		int getTuioBlob3DCount();
+
+		/**
+		 * Returns a List with a copy of currently active TuioBlobs3D
+		 *
+		 * @return  a List with a copy of all currently active TuioBlobs3D
+		 */
+		std::list<TuioBlob3D> copyTuioBlobs3D();
+
+		/**
+		 * Returns the TuioObject corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioObject
+		 *
+		 * @return  an active TuioObject corresponding to the provided Session ID or NULL
+		 */
+		TuioObject3D* getTuioObject3D(long s_id);
+
+		/**
+		 * Returns the TuioCursor3D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioCursor3D
+		 *
+		 * @return  an active TuioCursor3D corresponding to the provided Session ID or NULL
+		 */
+		TuioCursor3D* getTuioCursor3D(long s_id);
+
+		/**
+		 * Returns the TuioBlob3D corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active TuioBlob3D
+		 *
+		 * @return  an active TuioBlob3D corresponding to the provided Session ID or NULL
+		 */
+		TuioBlob3D* getTuioBlob3D(long s_id);
+
+		/**
+		 * Locks the TuioObject3D list in order to avoid updates during access
+		 */
+		void lockObject3DList();
+
+		/**
+		 * Releases the lock of the TuioObject list
+		 */
+		void unlockObject3DList();
+
+		/**
+		 * Locks the TuioCursor3D list in order to avoid updates during access
+		 */
+		void lockCursor3DList();
+
+		/**
+		 * Releases the lock of the TuioCursor3D list
+		 */
+		void unlockCursor3DList();
+
+		/**
+		 * Locks the TuioBlob3D list in order to avoid updates during access
+		 */
+		void lockBlob3DList();
+
+		/**
+		 * Releases the lock of the TuioBlob3D list
+		 */
+		void unlockBlob3DList();
+#pragma endregion 
+
+
+
 	protected:
 		std::list<TuioListener*> listenerList;
 		
 		std::list<TuioObject*> objectList;
 		std::list<TuioCursor*> cursorList;
 		std::list<TuioBlob*> blobList;
+
+		std::list<TuioObject25D*> object25DList;
+		std::list<TuioCursor25D*> cursor25DList;
+		std::list<TuioBlob25D*> blob25DList;
+
+		std::list<TuioObject3D*> object3DList;
+		std::list<TuioCursor3D*> cursor3DList;
+		std::list<TuioBlob3D*> blob3DList;
 		
 #ifdef WIN32
 		HANDLE objectMutex;
 		HANDLE cursorMutex;
 		HANDLE blobMutex;
+		HANDLE object25DMutex;
+		HANDLE cursor25DMutex;
+		HANDLE blob25DMutex;
+		HANDLE object3DMutex;
+		HANDLE cursor3DMutex;
+		HANDLE blob3DMutex;
 #else
 		pthread_mutex_t objectMutex;
 		pthread_mutex_t cursorMutex;
 		pthread_mutex_t blobMutex;
+		pthread_mutex_t object25DMutex;
+		pthread_mutex_t cursor25DMutex;
+		pthread_mutex_t blob25DMutex;
+		pthread_mutex_t object3DMutex;
+		pthread_mutex_t cursor3DMutex;
+		pthread_mutex_t blob3DMutex;
 #endif
 				
 	};

--- a/TUIO/TuioDispatcher.h
+++ b/TUIO/TuioDispatcher.h
@@ -69,7 +69,7 @@ namespace TUIO {
 		 */
 		void removeAllTuioListeners();
 		
-#pragma region 2D
+#pragma region region2D
 		/**
 		 * Returns a List of all currently active TuioObjects
 		 *
@@ -188,7 +188,7 @@ namespace TUIO {
 		void unlockBlobList();
 #pragma endregion 
 
-#pragma region 2.5D
+#pragma region region25D
 		/**
 		 * Returns a List of all currently active TuioObjects25D
 		 *
@@ -308,7 +308,7 @@ namespace TUIO {
 #pragma endregion 
 
 
-#pragma region 3D
+#pragma region region3D
 		/**
 		 * Returns a List of all currently active TuioObjects3D
 		 *

--- a/TUIO/TuioDispatcher.h
+++ b/TUIO/TuioDispatcher.h
@@ -1,6 +1,8 @@
+
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -34,7 +36,7 @@ namespace TUIO {
 	 * registered classes that implement the {@link TuioListener} interface.</p> 
 	 *
 	 * @author Martin Kaltenbrunner
-	 * @version 1.1.6
+	 * @version 1.1.7
 	 */ 
 	class LIBDECL TuioDispatcher { 
 		

--- a/TUIO/TuioListener.h
+++ b/TUIO/TuioListener.h
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -22,6 +22,16 @@
 #include "TuioObject.h"
 #include "TuioCursor.h"
 #include "TuioBlob.h"
+
+#include "TuioObject25D.h"
+#include "TuioCursor25D.h"
+#include "TuioBlob25D.h"
+
+#include "TuioObject3D.h"
+#include "TuioCursor3D.h"
+#include "TuioBlob3D.h"
+
+#include "TuioCustom.h"
 
 namespace TUIO {
 	
@@ -39,8 +49,8 @@ namespace TUIO {
 	 * client.start();<br/>
 	 * </code></p>
 	 *
-	 * @author Martin Kaltenbrunner
-	 * @version 1.1.6
+	 * @author Nicolas Bremard
+	 * @version 1.1.7
 	 */
 	class LIBDECL TuioListener { 
 		
@@ -50,75 +60,219 @@ namespace TUIO {
 		 */
 		virtual ~TuioListener(){};
 		
+#pragma region 2D
+
 		/**
 		 * This callback method is invoked by the TuioClient when a new TuioObject is added to the session.   
 		 *
 		 * @param  tobj  the TuioObject reference associated to the addTuioObject event
 		 */
-		virtual void addTuioObject(TuioObject *tobj)=0;
+		virtual void addTuioObject(TuioObject *tobj){}
 
 		/**
 		 * This callback method is invoked by the TuioClient when an existing TuioObject is updated during the session.   
 		 *
 		 * @param  tobj  the TuioObject reference associated to the updateTuioObject event
 		 */
-		virtual void updateTuioObject(TuioObject *tobj)=0;
+		virtual void updateTuioObject(TuioObject *tobj){}
 		
 		/**
 		 * This callback method is invoked by the TuioClient when an existing TuioObject is removed from the session.   
 		 *
 		 * @param  tobj  the TuioObject reference associated to the removeTuioObject event
 		 */
-		virtual void removeTuioObject(TuioObject *tobj)=0;
+		virtual void removeTuioObject(TuioObject *tobj){}
 		
 		/**
 		 * This callback method is invoked by the TuioClient when a new TuioCursor is added to the session.   
 		 *
 		 * @param  tcur  the TuioCursor reference associated to the addTuioCursor event
 		 */
-		virtual void addTuioCursor(TuioCursor *tcur)=0;
+		virtual void addTuioCursor(TuioCursor *tcur){}
 
 		/**
 		 * This callback method is invoked by the TuioClient when an existing TuioCursor is updated during the session.   
 		 *
 		 * @param  tcur  the TuioCursor reference associated to the updateTuioCursor event
 		 */
-		virtual void updateTuioCursor(TuioCursor *tcur)=0;
+		virtual void updateTuioCursor(TuioCursor *tcur){}
 
 		/**
 		 * This callback method is invoked by the TuioClient when an existing TuioCursor is removed from the session.   
 		 *
 		 * @param  tcur  the TuioCursor reference associated to the removeTuioCursor event
 		 */
-		virtual void removeTuioCursor(TuioCursor *tcur)=0;
+		virtual void removeTuioCursor(TuioCursor *tcur){}
 
 		/**
 		 * This callback method is invoked by the TuioClient when a new TuioBlob is added to the session.   
 		 *
 		 * @param  tcur  the TuioBlob reference associated to the addTuioBlob event
 		 */
-		virtual void addTuioBlob(TuioBlob *tblb)=0;
+		virtual void addTuioBlob(TuioBlob *tblb){}
 		
 		/**
 		 * This callback method is invoked by the TuioClient when an existing TuioBlob is updated during the session.   
 		 *
 		 * @param  tblb  the TuioBlob reference associated to the updateTuioBlob event
 		 */
-		virtual void updateTuioBlob(TuioBlob *tblb)=0;
+		virtual void updateTuioBlob(TuioBlob *tblb){}
 		
 		/**
 		 * This callback method is invoked by the TuioClient when an existing TuioBlob is removed from the session.   
 		 *
 		 * @param  tblb  the TuioBlob reference associated to the removeTuioBlob event
 		 */
-		virtual void removeTuioBlob(TuioBlob *tblb)=0;
+		virtual void removeTuioBlob(TuioBlob *tblb){}
+
+#pragma endregion 2D
+
+#pragma region 2.5D
+			   
+		/**
+		 * This callback method is invoked by the TuioClient when a new TuioObject25D is added to the session.
+		 *
+		 * @param  tobj  the TuioObject25D reference associated to the addTuioObject25D event
+		 */
+		virtual void addTuioObject25D(TuioObject25D *tobj) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioObject25D is updated during the session.
+		 *
+		 * @param  tobj  the TuioObject25D reference associated to the updateTuioObject25D event
+		 */
+		virtual void updateTuioObject25D(TuioObject25D *tobj) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioObject25D is removed from the session.
+		 *
+		 * @param  tobj  the TuioObject25D reference associated to the removeTuioObject25D event
+		 */
+		virtual void removeTuioObject25D(TuioObject25D *tobj) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when a new TuioCursor25D is added to the session.
+		 *
+		 * @param  tcur  the TuioCursor25D reference associated to the addTuioCursor25D event
+		 */
+		virtual void addTuioCursor25D(TuioCursor25D *tcur) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioCursor25D is updated during the session.
+		 *
+		 * @param  tcur  the TuioCursor25D reference associated to the updateTuioCursor25D event
+		 */
+		virtual void updateTuioCursor25D(TuioCursor25D *tcur) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioCursor25D is removed from the session.
+		 *
+		 * @param  tcur  the TuioCursor25D reference associated to the removeTuioCursor25D event
+		 */
+		virtual void removeTuioCursor25D(TuioCursor25D *tcur) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when a new TuioBlob25D is added to the session.
+		 *
+		 * @param  tcur  the TuioBlob25D reference associated to the addTuioBlob25D event
+		 */
+		virtual void addTuioBlob25D(TuioBlob25D *tblb) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioBlob25D is updated during the session.
+		 *
+		 * @param  tblb  the TuioBlob25D reference associated to the updateTuioBlob25D event
+		 */
+		virtual void updateTuioBlob25D(TuioBlob25D *tblb) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioBlob25D is removed from the session.
+		 *
+		 * @param  tblb  the TuioBlob25D reference associated to the removeTuioBlob25D event
+		 */
+		virtual void removeTuioBlob25D(TuioBlob25D *tblb) {}
+#pragma endregion 2.5D
+
+#pragma region 3D
+
+		/**
+		 * This callback method is invoked by the TuioClient when a new TuioObject3D is added to the session.
+		 *
+		 * @param  tobj  the TuioObject3D reference associated to the addTuioObject3D event
+		 */
+		virtual void addTuioObject3D(TuioObject3D *tobj) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioObject3D is updated during the session.
+		 *
+		 * @param  tobj  the TuioObject3D reference associated to the updateTuioObject3D event
+		 */
+		virtual void updateTuioObject3D(TuioObject3D *tobj) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioObject3D is removed from the session.
+		 *
+		 * @param  tobj  the TuioObject3D reference associated to the removeTuioObject3D event
+		 */
+		virtual void removeTuioObject3D(TuioObject3D *tobj) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when a new TuioCursor3D is added to the session.
+		 *
+		 * @param  tcur  the TuioCursor3D reference associated to the addTuioCursor3D event
+		 */
+		virtual void addTuioCursor3D(TuioCursor3D *tcur) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioCursor3D is updated during the session.
+		 *
+		 * @param  tcur  the TuioCursor3D reference associated to the updateTuioCursor3D event
+		 */
+		virtual void updateTuioCursor3D(TuioCursor3D *tcur) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioCursor3D is removed from the session.
+		 *
+		 * @param  tcur  the TuioCursor3D reference associated to the removeTuioCursor3D event
+		 */
+		virtual void removeTuioCursor3D(TuioCursor3D *tcur) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when a new TuioBlob3D is added to the session.
+		 *
+		 * @param  tcur  the TuioBlob3D reference associated to the addTuioBlob3D event
+		 */
+		virtual void addTuioBlob3D(TuioBlob3D *tblb) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioBlob3D is updated during the session.
+		 *
+		 * @param  tblb  the TuioBlob3D reference associated to the updateTuioBlob3D event
+		 */
+		virtual void updateTuioBlob3D(TuioBlob3D *tblb) {}
+
+		/**
+		 * This callback method is invoked by the TuioClient when an existing TuioBlob3D is removed from the session.
+		 *
+		 * @param  tblb  the TuioBlob3D reference associated to the removeTuioBlob3D event
+		 */
+		virtual void removeTuioBlob3D(TuioBlob3D *tblb) {}
+#pragma endregion 3D
+
+		/**
+		 * This callback method is invoked by the TuioClient when a new TuioObject is added to the session.
+		 *
+		 * @param  tobj  the TuioObject reference associated to the addTuioObject event
+		 */
+		virtual void customMessage(TuioCustom *tcus) {}
+
 		
 		/**
 		 * This callback method is invoked by the TuioClient to mark the end of a received TUIO message bundle.   
 		 *
 		 * @param  ftime  the TuioTime associated to the current TUIO message bundle
 		 */
-		virtual void refresh(TuioTime ftime)=0;
+		virtual void refresh(TuioTime ftime){}
 	};
 }
 #endif /* INCLUDED_TUIOLISTENER_H */

--- a/TUIO/TuioListener.h
+++ b/TUIO/TuioListener.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -15,7 +16,6 @@
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
-
 #ifndef INCLUDED_TUIOLISTENER_H
 #define INCLUDED_TUIOLISTENER_H
 
@@ -36,8 +36,8 @@
 namespace TUIO {
 	
 	/**
-	 * <p>The TuioListener interface provides a simple callback infrastructure which is used by the {@link TuioClient} class 
-	 * to dispatch TUIO events to all registered instances of classes that implement the TuioListener interface defined here.</p> 
+	 * <p>The TuioListener interface provides a simple callback infrastructure which is used by the {@link TuioClient} class
+	 * to dispatch TUIO events to all registered instances of classes that implement the TuioListener interface defined here.</p>
 	 * <p>Any class that implements the TuioListener interface is required to implement all of the callback methods defined here.
 	 * The {@link TuioClient} makes use of these interface methods in order to dispatch TUIO events to all registered TuioListener implementations.</p>
 	 * <p><code>
@@ -49,7 +49,7 @@ namespace TUIO {
 	 * client.start();<br/>
 	 * </code></p>
 	 *
-	 * @author Nicolas Bremard
+	 * @author Martin Kaltenbrunner
 	 * @version 1.1.7
 	 */
 	class LIBDECL TuioListener { 

--- a/TUIO/TuioListener.h
+++ b/TUIO/TuioListener.h
@@ -60,7 +60,8 @@ namespace TUIO {
 		 */
 		virtual ~TuioListener(){};
 		
-#pragma region 2D
+
+#pragma region region2D
 
 		/**
 		 * This callback method is invoked by the TuioClient when a new TuioObject is added to the session.   
@@ -125,9 +126,9 @@ namespace TUIO {
 		 */
 		virtual void removeTuioBlob(TuioBlob *tblb){}
 
-#pragma endregion 2D
+#pragma endregion region2D
 
-#pragma region 2.5D
+#pragma region region25D
 			   
 		/**
 		 * This callback method is invoked by the TuioClient when a new TuioObject25D is added to the session.
@@ -191,9 +192,9 @@ namespace TUIO {
 		 * @param  tblb  the TuioBlob25D reference associated to the removeTuioBlob25D event
 		 */
 		virtual void removeTuioBlob25D(TuioBlob25D *tblb) {}
-#pragma endregion 2.5D
+#pragma endregion region25D
 
-#pragma region 3D
+#pragma region region3D
 
 		/**
 		 * This callback method is invoked by the TuioClient when a new TuioObject3D is added to the session.
@@ -257,7 +258,7 @@ namespace TUIO {
 		 * @param  tblb  the TuioBlob3D reference associated to the removeTuioBlob3D event
 		 */
 		virtual void removeTuioBlob3D(TuioBlob3D *tblb) {}
-#pragma endregion 3D
+#pragma endregion region3D
 
 		/**
 		 * This callback method is invoked by the TuioClient when a new TuioObject is added to the session.

--- a/TUIO/TuioManager.cpp
+++ b/TUIO/TuioManager.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioManager.cpp
+++ b/TUIO/TuioManager.cpp
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -25,14 +25,27 @@ TuioManager::TuioManager()
 	, currentFrame(-1)
 	, maxCursorID(-1)
 	, maxBlobID(-1)
+	, maxCursor25DID(-1)
+	, maxBlob25DID(-1)
+	, maxCursor3DID(-1)
+	, maxBlob3DID(-1)
 	, sessionID(-1)
 	, updateObject(false)
 	, updateCursor(false)
 	, updateBlob(false)
+	, updateObject25D(false)
+	, updateCursor25D(false)
+	, updateBlob25D(false)
+	, updateObject3D(false)
+	, updateCursor3D(false)
+	, updateBlob3D(false)
 	, verbose(false)
 	, invert_x(false)
 	, invert_y(false)
+	, invert_z(false)
 	, invert_a(false)
+	, invert_b(false)
+	, invert_c(false)
 {
 
 }
@@ -133,7 +146,7 @@ TuioCursor* TuioManager::addTuioCursor(float x, float y) {
 		std::list<TuioCursor*>::iterator closestCursor = freeCursorList.begin();
 		
 		for(std::list<TuioCursor*>::iterator iter = freeCursorList.begin();iter!= freeCursorList.end(); iter++) {
-			if((*iter)->getDistance(x,y)<(*closestCursor)->getDistance(x,y)) closestCursor = iter;
+			if((*iter)->getDistance(x,y,0)<(*closestCursor)->getDistance(x,y,0)) closestCursor = iter;
 		}
 		
 		TuioCursor *freeCursor = (*closestCursor);
@@ -171,7 +184,7 @@ void TuioManager::addExternalTuioCursor(TuioCursor *tcur) {
 void TuioManager::updateTuioCursor(TuioCursor *tcur,float x, float y) {
 	if (tcur==NULL) return;
 	//if (tcur->getTuioTime()==currentFrameTime) return;
-	tcur->update(currentFrameTime,x,y);
+	tcur->update(currentFrameTime,x,y,0);
 	updateCursor = true;
 
 	if (tcur->isMoving()) {	
@@ -264,7 +277,7 @@ TuioBlob* TuioManager::addTuioBlob(float x, float y, float a, float w, float h, 
 		std::list<TuioBlob*>::iterator closestBlob = freeBlobList.begin();
 		
 		for(std::list<TuioBlob*>::iterator iter = freeBlobList.begin();iter!= freeBlobList.end(); iter++) {
-			if((*iter)->getDistance(x,y)<(*closestBlob)->getDistance(x,y)) closestBlob = iter;
+			if((*iter)->getDistance(x,y,0)<(*closestBlob)->getDistance(x,y,0)) closestBlob = iter;
 		}
 		
 		TuioBlob *freeBlob = (*closestBlob);
@@ -294,7 +307,7 @@ void TuioManager::addExternalTuioBlob(TuioBlob *tblb) {
 		std::list<TuioBlob*>::iterator closestBlob = freeBlobList.begin();
 		
 		for(std::list<TuioBlob*>::iterator iter = freeBlobList.begin();iter!= freeBlobList.end(); iter++) {
-			if((*iter)->getDistance(tblb->getX(),tblb->getY())<(*closestBlob)->getDistance(tblb->getX(),tblb->getY())) closestBlob = iter;
+			if((*iter)->getDistance(tblb->getX(),tblb->getY(),0)<(*closestBlob)->getDistance(tblb->getX(),tblb->getY(),0)) closestBlob = iter;
 		}
 		
 		TuioBlob *freeBlob = (*closestBlob);
@@ -405,6 +418,788 @@ void TuioManager::removeExternalTuioBlob(TuioBlob *tblb) {
 		(*listener)->removeTuioBlob(tblb);
 }
 
+
+
+
+
+
+
+
+TuioObject25D* TuioManager::addTuioObject25D(int f_id, float x, float y, float z, float a) {
+	sessionID++;
+	TuioObject25D *tobj = new TuioObject25D(currentFrameTime, sessionID, f_id, x, y, z, a);
+	object25DList.push_back(tobj);
+	updateObject25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioObject25D(tobj);
+
+	if (verbose)
+		std::cout << "add 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getAngle() << std::endl;
+
+	return tobj;
+}
+
+void TuioManager::addExternalTuioObject25D(TuioObject25D *tobj) {
+	if (tobj == NULL) return;
+	tobj->setSessionID(++sessionID);
+	object25DList.push_back(tobj);
+	updateObject25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioObject25D(tobj);
+
+	if (verbose)
+		std::cout << "add 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getAngle() << std::endl;
+}
+
+void TuioManager::updateTuioObject25D(TuioObject25D *tobj, float x, float y,float z, float a) {
+	if (tobj == NULL) return;
+	if (tobj->getTuioTime() == currentFrameTime) return;
+	tobj->update(currentFrameTime, x, y,z, a);
+	updateObject25D = true;
+
+	if (tobj->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioObject25D(tobj);
+
+		if (verbose)
+			std::cout << "set 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getAngle()
+			<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRotationSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+	}
+}
+
+void TuioManager::updateExternalTuioObject25D(TuioObject25D *tobj) {
+	if (tobj == NULL) return;
+	updateObject25D = true;
+
+	if (tobj->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioObject25D(tobj);
+
+		if (verbose)
+			std::cout << "set 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getAngle()
+			<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRotationSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+	}
+}
+
+void TuioManager::removeTuioObject25D(TuioObject25D  *tobj) {
+	if (tobj == NULL) return;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioObject25D(tobj);
+
+	if (verbose)
+		std::cout << "del 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ")" << std::endl;
+
+	object25DList.remove(tobj);
+	delete tobj;
+	updateObject25D = true;
+}
+
+void TuioManager::removeExternalTuioObject25D(TuioObject25D *tobj) {
+	if (tobj == NULL) return;
+	object25DList.remove(tobj);
+	updateObject25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioObject25D(tobj);
+
+	if (verbose)
+		std::cout << "del 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ")" << std::endl;
+}
+
+TuioCursor25D* TuioManager::addTuioCursor25D(float x, float y, float z) {
+	sessionID++;
+
+	int cursorID = (int)cursor25DList.size();
+	if ((int)(cursor25DList.size()) <= maxCursor25DID) {
+		std::list<TuioCursor25D*>::iterator closestCursor = freeCursor25DList.begin();
+
+		for (std::list<TuioCursor25D*>::iterator iter = freeCursor25DList.begin(); iter != freeCursor25DList.end(); iter++) {
+			if ((*iter)->getDistance(x, y, z) < (*closestCursor)->getDistance(x, y, z)) closestCursor = iter;
+		}
+
+		TuioCursor25D *freeCursor = (*closestCursor);
+		cursorID = (*closestCursor)->getCursorID();
+		freeCursor25DList.erase(closestCursor);
+		delete freeCursor;
+	}
+	else maxCursor25DID = cursorID;
+
+	TuioCursor25D *tcur = new TuioCursor25D(currentFrameTime, sessionID, cursorID, x, y,z);
+	cursor25DList.push_back(tcur);
+	updateCursor25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioCursor25D(tcur);
+
+	if (verbose /*&& tcur->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "add 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ() << std::endl;
+
+	return tcur;
+}
+
+void TuioManager::addExternalTuioCursor25D(TuioCursor25D *tcur) {
+	if (tcur == NULL) return;
+	tcur->setSessionID(++sessionID);
+	cursor25DList.push_back(tcur);
+	updateCursor25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioCursor25D(tcur);
+
+	if (verbose)
+		std::cout << "add 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ() << std::endl;
+}
+
+void TuioManager::updateTuioCursor25D(TuioCursor25D *tcur, float x, float y, float z) {
+	if (tcur == NULL) return;
+	//if (tcur->getTuioTime()==currentFrameTime) return;
+	tcur->update(currentFrameTime, x, y, z);
+	updateCursor25D = true;
+
+	if (tcur->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioCursor25D(tcur);
+
+		if (verbose)
+			std::cout << "set 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+			<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+	}
+}
+
+void TuioManager::updateExternalTuioCursor25D(TuioCursor25D *tcur) {
+	if (tcur == NULL) return;
+	updateCursor25D = true;
+
+	if (tcur->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioCursor25D(tcur);
+
+		if (verbose)
+			std::cout << "set 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+			<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+	}
+}
+
+void TuioManager::removeTuioCursor25D(TuioCursor25D *tcur) {
+	if (tcur == NULL) return;
+
+	if (verbose /*&& tcur->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "del 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ")" << std::endl;
+
+	cursor25DList.remove(tcur);
+	tcur->remove(currentFrameTime);
+	updateCursor25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioCursor25D(tcur);
+
+	if (tcur->getCursorID() == maxCursor25DID) {
+		maxCursor25DID = -1;
+		delete tcur;
+
+		if (cursor25DList.size() > 0) {
+			std::list<TuioCursor25D*>::iterator clist;
+			for (clist = cursor25DList.begin(); clist != cursor25DList.end(); clist++) {
+				int cursorID = (*clist)->getCursorID();
+				if (cursorID > maxCursor25DID) maxCursor25DID = cursorID;
+			}
+
+			freeCursor25DBuffer.clear();
+			for (std::list<TuioCursor25D*>::iterator flist = freeCursor25DList.begin(); flist != freeCursor25DList.end(); flist++) {
+				TuioCursor25D *freeCursor = (*flist);
+				if (freeCursor->getCursorID() > maxCursor25DID) delete freeCursor;
+				else freeCursor25DBuffer.push_back(freeCursor);
+			}
+
+			freeCursor25DList = freeCursor25DBuffer;
+
+		}
+		else {
+			for (std::list<TuioCursor25D*>::iterator flist = freeCursor25DList.begin(); flist != freeCursor25DList.end(); flist++) {
+				TuioCursor25D *freeCursor = (*flist);
+				delete freeCursor;
+			}
+			freeCursor25DList.clear();
+		}
+	}
+	else if (tcur->getCursorID() < maxCursor25DID) {
+		freeCursor25DList.push_back(tcur);
+	}
+}
+
+void TuioManager::removeExternalTuioCursor25D(TuioCursor25D *tcur) {
+	if (tcur == NULL) return;
+
+	if (verbose /*&& tcur->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "del 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ")" << std::endl;
+
+	cursor25DList.remove(tcur);
+	updateCursor25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioCursor25D(tcur);
+}
+
+TuioBlob25D* TuioManager::addTuioBlob25D(float x, float y,float z, float a, float w, float h, float f) {
+	sessionID++;
+
+	int blobID = (int)blob25DList.size();
+	if ((int)(blob25DList.size()) <= maxBlob25DID) {
+		std::list<TuioBlob25D*>::iterator closestBlob = freeBlob25DList.begin();
+
+		for (std::list<TuioBlob25D*>::iterator iter = freeBlob25DList.begin(); iter != freeBlob25DList.end(); iter++) {
+			if ((*iter)->getDistance(x, y, z) < (*closestBlob)->getDistance(x, y, z)) closestBlob = iter;
+		}
+
+		TuioBlob25D *freeBlob = (*closestBlob);
+		blobID = (*closestBlob)->getBlobID();
+		freeBlob25DList.erase(closestBlob);
+		delete freeBlob;
+	}
+	else maxBlob25DID = blobID;
+
+	TuioBlob25D *tblb = new TuioBlob25D(currentFrameTime, sessionID, blobID, x, y,z, a, w, h, f);
+	blob25DList.push_back(tblb);
+	updateBlob25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioBlob25D(tblb);
+
+	if (verbose /*&& tblb->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "add 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea() << std::endl;
+
+	return tblb;
+}
+
+void TuioManager::addExternalTuioBlob25D(TuioBlob25D *tblb) {
+	if (tblb == NULL) return;
+
+	int blobID = (int)blob25DList.size();
+	if (blobID <= maxBlob25DID) {
+		std::list<TuioBlob25D*>::iterator closestBlob = freeBlob25DList.begin();
+
+		for (std::list<TuioBlob25D*>::iterator iter = freeBlob25DList.begin(); iter != freeBlob25DList.end(); iter++) {
+			if ((*iter)->getDistance(tblb->getX(), tblb->getY(), tblb->getZ()) < (*closestBlob)->getDistance(tblb->getX(), tblb->getY(), tblb->getY())) closestBlob = iter;
+		}
+
+		TuioBlob25D *freeBlob = (*closestBlob);
+		blobID = (*closestBlob)->getBlobID();
+		freeBlob25DList.erase(closestBlob);
+		delete freeBlob;
+	}
+	else maxBlob25DID = blobID;
+
+	tblb->setSessionID(++sessionID);
+	tblb->setBlobID(blobID);
+
+	blob25DList.push_back(tblb);
+	updateBlob25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioBlob25D(tblb);
+
+	if (verbose)
+		std::cout << "add 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea() << std::endl;
+}
+
+void TuioManager::updateTuioBlob25D(TuioBlob25D *tblb, float x, float y,float z, float a, float w, float h, float f) {
+	if (tblb == NULL) return;
+	if (tblb->getTuioTime() == currentFrameTime) return;
+	tblb->update(currentFrameTime, x, y, z, a, w, h, f);
+	updateBlob25D = true;
+
+	if (tblb->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioBlob25D(tblb);
+
+		if (verbose)
+			std::cout << "set 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea()
+			<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRotationSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << " " << std::endl;
+	}
+}
+
+void TuioManager::updateExternalTuioBlob25D(TuioBlob25D *tblb) {
+	if (tblb == NULL) return;
+	updateBlob25D = true;
+
+	if (tblb->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioBlob25D(tblb);
+
+		if (verbose)
+			std::cout << "set 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea()
+			<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRotationSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << " " << std::endl;
+	}
+}
+
+void TuioManager::removeTuioBlob25D(TuioBlob25D *tblb) {
+	if (tblb == NULL) return;
+
+	if (verbose /*&& tblb->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "del 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ")" << std::endl;
+
+	blob25DList.remove(tblb);
+	tblb->remove(currentFrameTime);
+	updateBlob25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioBlob25D(tblb);
+
+	if (tblb->getBlobID() == maxBlob25DID) {
+		maxBlob25DID = -1;
+		delete tblb;
+
+		if (blob25DList.size() > 0) {
+			std::list<TuioBlob25D*>::iterator clist;
+			for (clist = blob25DList.begin(); clist != blob25DList.end(); clist++) {
+				int blobID = (*clist)->getBlobID();
+				if (blobID > maxBlob25DID) maxBlob25DID = blobID;
+			}
+
+			freeBlob25DBuffer.clear();
+			for (std::list<TuioBlob25D*>::iterator flist = freeBlob25DList.begin(); flist != freeBlob25DList.end(); flist++) {
+				TuioBlob25D *freeBlob = (*flist);
+				if (freeBlob->getBlobID() > maxBlob25DID) delete freeBlob;
+				else freeBlob25DBuffer.push_back(freeBlob);
+			}
+
+			freeBlob25DList = freeBlob25DBuffer;
+
+		}
+		else {
+			for (std::list<TuioBlob25D*>::iterator flist = freeBlob25DList.begin(); flist != freeBlob25DList.end(); flist++) {
+				TuioBlob25D *freeBlob = (*flist);
+				delete freeBlob;
+			}
+			freeBlob25DList.clear();
+		}
+	}
+	else if (tblb->getBlobID() < maxBlob25DID) {
+		freeBlob25DList.push_back(tblb);
+	}
+
+}
+
+void TuioManager::removeExternalTuioBlob25D(TuioBlob25D *tblb) {
+	if (tblb == NULL) return;
+
+	if (verbose /*&& tblb->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "del 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ")" << std::endl;
+
+	blob25DList.remove(tblb);
+	updateBlob25D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioBlob25D(tblb);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+TuioObject3D* TuioManager::addTuioObject3D(int f_id, float x, float y, float z, float roll, float pitch, float yaw) {
+	sessionID++;
+	TuioObject3D *tobj = new TuioObject3D(currentFrameTime, sessionID, f_id, x, y, z, roll, pitch, yaw);
+	object3DList.push_back(tobj);
+	updateObject3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioObject3D(tobj);
+
+	if (verbose)
+		std::cout << "add 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getRoll() << " " << tobj->getPitch() << " " << tobj->getYaw() << std::endl;
+
+	return tobj;
+}
+
+void TuioManager::addExternalTuioObject3D(TuioObject3D *tobj) {
+	if (tobj == NULL) return;
+	tobj->setSessionID(++sessionID);
+	object3DList.push_back(tobj);
+	updateObject3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioObject3D(tobj);
+
+	if (verbose)
+		std::cout << "add 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getRoll() << " " << tobj->getPitch() << " " << tobj->getYaw() << std::endl;
+}
+
+void TuioManager::updateTuioObject3D(TuioObject3D *tobj, float x, float y, float z, float roll, float pitch, float yaw) {
+	if (tobj == NULL) return;
+	if (tobj->getTuioTime() == currentFrameTime) return;
+	tobj->update(currentFrameTime, x, y, z, roll, pitch, yaw);
+	updateObject3D = true;
+
+	if (tobj->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioObject3D(tobj);
+
+		if (verbose)
+			std::cout << "set 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getRoll() << " " << tobj->getPitch() << " " << tobj->getYaw()
+			<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRollSpeed() << " " << tobj->getPitchSpeed() << " " << tobj->getYawSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+	}
+}
+
+void TuioManager::updateExternalTuioObject3D(TuioObject3D *tobj) {
+	if (tobj == NULL) return;
+	updateObject3D = true;
+
+	if (tobj->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioObject3D(tobj);
+
+		if (verbose)
+			std::cout << "set 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getZ() << " " << tobj->getRoll() << " " << tobj->getPitch() << " " << tobj->getYaw()
+			<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRollSpeed() << " " << tobj->getPitchSpeed() << " " << tobj->getYawSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+	}
+}
+
+void TuioManager::removeTuioObject3D(TuioObject3D  *tobj) {
+	if (tobj == NULL) return;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioObject3D(tobj);
+
+	if (verbose)
+		std::cout << "del 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ")" << std::endl;
+
+	object3DList.remove(tobj);
+	delete tobj;
+	updateObject3D = true;
+}
+
+void TuioManager::removeExternalTuioObject3D(TuioObject3D *tobj) {
+	if (tobj == NULL) return;
+	object3DList.remove(tobj);
+	updateObject3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioObject3D(tobj);
+
+	if (verbose)
+		std::cout << "del 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ")" << std::endl;
+}
+
+TuioCursor3D* TuioManager::addTuioCursor3D(float x, float y, float z) {
+	sessionID++;
+
+	int cursorID = (int)cursor3DList.size();
+	if ((int)(cursor3DList.size()) <= maxCursor3DID) {
+		std::list<TuioCursor3D*>::iterator closestCursor = freeCursor3DList.begin();
+
+		for (std::list<TuioCursor3D*>::iterator iter = freeCursor3DList.begin(); iter != freeCursor3DList.end(); iter++) {
+			if ((*iter)->getDistance(x, y, z) < (*closestCursor)->getDistance(x, y, z)) closestCursor = iter;
+		}
+
+		TuioCursor3D *freeCursor = (*closestCursor);
+		cursorID = (*closestCursor)->getCursorID();
+		freeCursor3DList.erase(closestCursor);
+		delete freeCursor;
+	}
+	else maxCursor3DID = cursorID;
+
+	TuioCursor3D *tcur = new TuioCursor3D(currentFrameTime, sessionID, cursorID, x, y, z);
+	cursor3DList.push_back(tcur);
+	updateCursor3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioCursor3D(tcur);
+
+	if (verbose /*&& tcur->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "add 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ() << std::endl;
+
+	return tcur;
+}
+
+void TuioManager::addExternalTuioCursor3D(TuioCursor3D *tcur) {
+	if (tcur == NULL) return;
+	tcur->setSessionID(++sessionID);
+	cursor3DList.push_back(tcur);
+	updateCursor3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioCursor3D(tcur);
+
+	if (verbose)
+		std::cout << "add 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ() << std::endl;
+}
+
+void TuioManager::updateTuioCursor3D(TuioCursor3D *tcur, float x, float y, float z) {
+	if (tcur == NULL) return;
+	//if (tcur->getTuioTime()==currentFrameTime) return;
+	tcur->update(currentFrameTime, x, y, z);
+	updateCursor3D = true;
+
+	if (tcur->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioCursor3D(tcur);
+
+		if (verbose)
+			std::cout << "set 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+			<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+	}
+}
+
+void TuioManager::updateExternalTuioCursor3D(TuioCursor3D *tcur) {
+	if (tcur == NULL) return;
+	updateCursor3D = true;
+
+	if (tcur->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioCursor3D(tcur);
+
+		if (verbose)
+			std::cout << "set 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+			<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+	}
+}
+
+void TuioManager::removeTuioCursor3D(TuioCursor3D *tcur) {
+	if (tcur == NULL) return;
+
+	if (verbose /*&& tcur->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "del 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ")" << std::endl;
+
+	cursor3DList.remove(tcur);
+	tcur->remove(currentFrameTime);
+	updateCursor3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioCursor3D(tcur);
+
+	if (tcur->getCursorID() == maxCursor3DID) {
+		maxCursor3DID = -1;
+		delete tcur;
+
+		if (cursor3DList.size() > 0) {
+			std::list<TuioCursor3D*>::iterator clist;
+			for (clist = cursor3DList.begin(); clist != cursor3DList.end(); clist++) {
+				int cursorID = (*clist)->getCursorID();
+				if (cursorID > maxCursor3DID) maxCursor3DID = cursorID;
+			}
+
+			freeCursor3DBuffer.clear();
+			for (std::list<TuioCursor3D*>::iterator flist = freeCursor3DList.begin(); flist != freeCursor3DList.end(); flist++) {
+				TuioCursor3D *freeCursor = (*flist);
+				if (freeCursor->getCursorID() > maxCursor3DID) delete freeCursor;
+				else freeCursor3DBuffer.push_back(freeCursor);
+			}
+
+			freeCursor3DList = freeCursor3DBuffer;
+
+		}
+		else {
+			for (std::list<TuioCursor3D*>::iterator flist = freeCursor3DList.begin(); flist != freeCursor3DList.end(); flist++) {
+				TuioCursor3D *freeCursor = (*flist);
+				delete freeCursor;
+			}
+			freeCursor3DList.clear();
+		}
+	}
+	else if (tcur->getCursorID() < maxCursor3DID) {
+		freeCursor3DList.push_back(tcur);
+	}
+}
+
+void TuioManager::removeExternalTuioCursor3D(TuioCursor3D *tcur) {
+	if (tcur == NULL) return;
+
+	if (verbose /*&& tcur->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "del 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ")" << std::endl;
+
+	cursor3DList.remove(tcur);
+	updateCursor3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioCursor3D(tcur);
+}
+
+TuioBlob3D* TuioManager::addTuioBlob3D(float x, float y, float z, float roll, float pitch, float yaw, float width, float height, float depth, float volume) {
+	sessionID++;
+
+	int blobID = (int)blob3DList.size();
+	if ((int)(blob3DList.size()) <= maxBlob3DID) {
+		std::list<TuioBlob3D*>::iterator closestBlob = freeBlob3DList.begin();
+
+		for (std::list<TuioBlob3D*>::iterator iter = freeBlob3DList.begin(); iter != freeBlob3DList.end(); iter++) {
+			if ((*iter)->getDistance(x, y, z) < (*closestBlob)->getDistance(x, y, z)) closestBlob = iter;
+		}
+
+		TuioBlob3D *freeBlob = (*closestBlob);
+		blobID = (*closestBlob)->getBlobID();
+		freeBlob3DList.erase(closestBlob);
+		delete freeBlob;
+	}
+	else maxBlob3DID = blobID;
+
+	TuioBlob3D *tblb = new TuioBlob3D(currentFrameTime, sessionID, blobID, x, y, z, roll, pitch, yaw, width, height, depth, volume);
+	blob3DList.push_back(tblb);
+	updateBlob3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioBlob3D(tblb);
+
+	if (verbose /*&& tblb->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "add 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getRoll() << " " << tblb->getPitch() << " " << tblb->getYaw() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getDepth() << " " << tblb->getVolume() << std::endl;
+
+	return tblb;
+}
+
+void TuioManager::addExternalTuioBlob3D(TuioBlob3D *tblb) {
+	if (tblb == NULL) return;
+
+	int blobID = (int)blob3DList.size();
+	if (blobID <= maxBlob3DID) {
+		std::list<TuioBlob3D*>::iterator closestBlob = freeBlob3DList.begin();
+
+		for (std::list<TuioBlob3D*>::iterator iter = freeBlob3DList.begin(); iter != freeBlob3DList.end(); iter++) {
+			if ((*iter)->getDistance(tblb->getX(), tblb->getY(), tblb->getZ()) < (*closestBlob)->getDistance(tblb->getX(), tblb->getY(), tblb->getY())) closestBlob = iter;
+		}
+
+		TuioBlob3D *freeBlob = (*closestBlob);
+		blobID = (*closestBlob)->getBlobID();
+		freeBlob3DList.erase(closestBlob);
+		delete freeBlob;
+	}
+	else maxBlob3DID = blobID;
+
+	tblb->setSessionID(++sessionID);
+	tblb->setBlobID(blobID);
+
+	blob3DList.push_back(tblb);
+	updateBlob3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->addTuioBlob3D(tblb);
+
+	if (verbose)
+		std::cout << "add 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getRoll() << " " << tblb->getPitch() << " " << tblb->getYaw() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getDepth() << " " << tblb->getVolume() << std::endl;
+}
+
+void TuioManager::updateTuioBlob3D(TuioBlob3D *tblb, float x, float y, float z, float roll, float pitch, float yaw, float width, float height, float depth, float volume) {
+	if (tblb == NULL) return;
+	if (tblb->getTuioTime() == currentFrameTime) return;
+	tblb->update(currentFrameTime, x, y, z, roll,pitch,yaw,width,height,depth,volume);
+	updateBlob3D = true;
+
+	if (tblb->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioBlob3D(tblb);
+
+		if (verbose)
+			std::cout << "set 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getRoll() << " " << tblb->getPitch() << " " << tblb->getYaw() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getDepth() << " " << tblb->getVolume()
+			<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRollSpeed() << " " << tblb->getPitchSpeed() << " " << tblb->getYawSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << " " << std::endl;
+	}
+}
+
+void TuioManager::updateExternalTuioBlob3D(TuioBlob3D *tblb) {
+	if (tblb == NULL) return;
+	updateBlob3D = true;
+
+	if (tblb->isMoving()) {
+		for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+			(*listener)->updateTuioBlob3D(tblb);
+
+		if (verbose)
+			std::cout << "set 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getRoll() << " " << tblb->getPitch() << " " << tblb->getYaw() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getDepth() << " " << tblb->getVolume()
+			<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRollSpeed() << " " << tblb->getPitchSpeed() << " " << tblb->getYawSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << " " << std::endl;
+	}
+}
+
+void TuioManager::removeTuioBlob3D(TuioBlob3D *tblb) {
+	if (tblb == NULL) return;
+
+	if (verbose /*&& tblb->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "del 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ")" << std::endl;
+
+	blob3DList.remove(tblb);
+	tblb->remove(currentFrameTime);
+	updateBlob3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioBlob3D(tblb);
+
+	if (tblb->getBlobID() == maxBlob3DID) {
+		maxBlob3DID = -1;
+		delete tblb;
+
+		if (blob3DList.size() > 0) {
+			std::list<TuioBlob3D*>::iterator clist;
+			for (clist = blob3DList.begin(); clist != blob3DList.end(); clist++) {
+				int blobID = (*clist)->getBlobID();
+				if (blobID > maxBlob3DID) maxBlob3DID = blobID;
+			}
+
+			freeBlob3DBuffer.clear();
+			for (std::list<TuioBlob3D*>::iterator flist = freeBlob3DList.begin(); flist != freeBlob3DList.end(); flist++) {
+				TuioBlob3D *freeBlob = (*flist);
+				if (freeBlob->getBlobID() > maxBlob3DID) delete freeBlob;
+				else freeBlob3DBuffer.push_back(freeBlob);
+			}
+
+			freeBlob3DList = freeBlob3DBuffer;
+
+		}
+		else {
+			for (std::list<TuioBlob3D*>::iterator flist = freeBlob3DList.begin(); flist != freeBlob3DList.end(); flist++) {
+				TuioBlob3D *freeBlob = (*flist);
+				delete freeBlob;
+			}
+			freeBlob3DList.clear();
+		}
+	}
+	else if (tblb->getBlobID() < maxBlob3DID) {
+		freeBlob3DList.push_back(tblb);
+	}
+
+}
+
+void TuioManager::removeExternalTuioBlob3D(TuioBlob3D *tblb) {
+	if (tblb == NULL) return;
+
+	if (verbose /*&& tblb->getTuioState()!=TUIO_ADDED*/)
+		std::cout << "del 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ")" << std::endl;
+
+	blob3DList.remove(tblb);
+	updateBlob3D = true;
+
+	for (std::list<TuioListener*>::iterator listener = listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->removeTuioBlob3D(tblb);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 long TuioManager::getSessionID() {
 	sessionID++;
 	return sessionID;
@@ -428,13 +1223,21 @@ void TuioManager::commitFrame() {
 		(*listener)->refresh(currentFrameTime);
 }
 
+
+
+
+
+
+
+
+
 TuioObject* TuioManager::getClosestTuioObject(float xp, float yp) {
 	
 	TuioObject *closestObject = NULL;
 	float closestDistance = 1.0f;
 	
 	for (std::list<TuioObject*>::iterator iter=objectList.begin(); iter != objectList.end(); iter++) {
-		float distance = (*iter)->getDistance(xp,yp);
+		float distance = (*iter)->getDistance(xp,yp,0);
 		if(distance<closestDistance) {
 			closestObject = (*iter);
 			closestDistance = distance;
@@ -450,7 +1253,7 @@ TuioCursor* TuioManager::getClosestTuioCursor(float xp, float yp) {
 	float closestDistance = 1.0f;
 
 	for (std::list<TuioCursor*>::iterator iter=cursorList.begin(); iter != cursorList.end(); iter++) {
-		float distance = (*iter)->getDistance(xp,yp);
+		float distance = (*iter)->getDistance(xp,yp,0);
 		if(distance<closestDistance) {
 			closestCursor = (*iter);
 			closestDistance = distance;
@@ -466,7 +1269,7 @@ TuioBlob* TuioManager::getClosestTuioBlob(float xp, float yp) {
 	float closestDistance = 1.0f;
 	
 	for (std::list<TuioBlob*>::iterator iter=blobList.begin(); iter != blobList.end(); iter++) {
-		float distance = (*iter)->getDistance(xp,yp);
+		float distance = (*iter)->getDistance(xp,yp,0);
 		if(distance<closestDistance) {
 			closestBlob = (*iter);
 			closestDistance = distance;
@@ -613,5 +1416,414 @@ void TuioManager::resetTuioBlobs() {
 	while (tuioBlob!=blobList.end()) {
 		removeTuioBlob((*tuioBlob));
 		tuioBlob = blobList.begin();
+	}
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+TuioObject25D* TuioManager::getClosestTuioObject25D(float xp, float yp,float zp) {
+
+	TuioObject25D *closestObject = NULL;
+	float closestDistance = 1.0f;
+
+	for (std::list<TuioObject25D*>::iterator iter = object25DList.begin(); iter != object25DList.end(); iter++) {
+		float distance = (*iter)->getDistance(xp, yp, zp);
+		if (distance < closestDistance) {
+			closestObject = (*iter);
+			closestDistance = distance;
+		}
+	}
+
+	return closestObject;
+}
+
+TuioCursor25D* TuioManager::getClosestTuioCursor25D(float xp, float yp, float zp) {
+
+	TuioCursor25D *closestCursor = NULL;
+	float closestDistance = 1.0f;
+
+	for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++) {
+		float distance = (*iter)->getDistance(xp, yp, zp);
+		if (distance < closestDistance) {
+			closestCursor = (*iter);
+			closestDistance = distance;
+		}
+	}
+
+	return closestCursor;
+}
+
+TuioBlob25D* TuioManager::getClosestTuioBlob25D(float xp, float yp,float zp) {
+
+	TuioBlob25D *closestBlob = NULL;
+	float closestDistance = 1.0f;
+
+	for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++) {
+		float distance = (*iter)->getDistance(xp, yp, zp);
+		if (distance < closestDistance) {
+			closestBlob = (*iter);
+			closestDistance = distance;
+		}
+	}
+
+	return closestBlob;
+}
+
+std::list<TuioObject25D*> TuioManager::getUntouchedObjects25D() {
+
+	std::list<TuioObject25D*> untouched;
+	for (std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin(); tuioObject != object25DList.end(); tuioObject++) {
+		TuioObject25D *tobj = (*tuioObject);
+		if (tobj->getTuioTime() != currentFrameTime) untouched.push_back(tobj);
+	}
+	return untouched;
+}
+
+void TuioManager::stopUntouchedMovingObjects25D() {
+
+	std::list<TuioObject25D*> untouched;
+	for (std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin(); tuioObject != object25DList.end(); tuioObject++) {
+
+		TuioObject25D *tobj = (*tuioObject);
+		if ((tobj->getTuioTime() != currentFrameTime) && (tobj->isMoving())) {
+			tobj->stop(currentFrameTime);
+			updateObject25D = true;
+			if (verbose)
+				std::cout << "set obj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getAngle()
+				<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRotationSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+		}
+	}
+}
+
+void TuioManager::removeUntouchedStoppedObjects25D() {
+
+	std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin();
+	while (tuioObject != object25DList.end()) {
+		TuioObject25D *tobj = (*tuioObject);
+		if ((tobj->getTuioTime() != currentFrameTime) && (!tobj->isMoving())) {
+			removeTuioObject25D(tobj);
+			tuioObject = object25DList.begin();
+		}
+		else tuioObject++;
+	}
+}
+
+void TuioManager::resetTuioObjects25D() {
+
+	std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin();
+	while (tuioObject != object25DList.end()) {
+		removeTuioObject25D((*tuioObject));
+		tuioObject = object25DList.begin();
+	}
+}
+
+std::list<TuioCursor25D*> TuioManager::getUntouchedCursors25D() {
+
+	std::list<TuioCursor25D*> untouched;
+	for (std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin(); tuioCursor != cursor25DList.end(); tuioCursor++) {
+		TuioCursor25D *tcur = (*tuioCursor);
+		if (tcur->getTuioTime() != currentFrameTime) untouched.push_back(tcur);
+	}
+	return untouched;
+}
+
+void TuioManager::stopUntouchedMovingCursors25D() {
+
+	std::list<TuioCursor25D*> untouched;
+	for (std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin(); tuioCursor != cursor25DList.end(); tuioCursor++) {
+		TuioCursor25D *tcur = (*tuioCursor);
+		if ((tcur->getTuioTime() != currentFrameTime) && (tcur->isMoving())) {
+			tcur->stop(currentFrameTime);
+			updateCursor25D = true;
+			if (verbose)
+				std::cout << "set cur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+				<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+		}
+	}
+}
+
+void TuioManager::removeUntouchedStoppedCursors25D() {
+
+	if (cursor25DList.size() == 0) return;
+	std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin();
+	while (tuioCursor != cursor25DList.end()) {
+		TuioCursor25D *tcur = (*tuioCursor);
+		if ((tcur->getTuioTime() != currentFrameTime) && (!tcur->isMoving())) {
+			removeTuioCursor25D(tcur);
+			tuioCursor = cursor25DList.begin();
+		}
+		else tuioCursor++;
+	}
+}
+
+void TuioManager::resetTuioCursors25D() {
+
+	std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin();
+	while (tuioCursor != cursor25DList.end()) {
+		removeTuioCursor25D((*tuioCursor));
+		tuioCursor = cursor25DList.begin();
+	}
+}
+
+std::list<TuioBlob25D*> TuioManager::getUntouchedBlobs25D() {
+
+	std::list<TuioBlob25D*> untouched;
+	for (std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin(); tuioBlob != blob25DList.end(); tuioBlob++) {
+		TuioBlob25D *tblb = (*tuioBlob);
+		if (tblb->getTuioTime() != currentFrameTime) untouched.push_back(tblb);
+	}
+	return untouched;
+}
+
+void TuioManager::stopUntouchedMovingBlobs25D() {
+
+	std::list<TuioBlob25D*> untouched;
+	for (std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin(); tuioBlob != blob25DList.end(); tuioBlob++) {
+		TuioBlob25D *tblb = (*tuioBlob);
+		if ((tblb->getTuioTime() != currentFrameTime) && (tblb->isMoving())) {
+			tblb->stop(currentFrameTime);
+			updateBlob25D = true;
+			if (verbose)
+				std::cout << "set blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea()
+				<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRotationSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << " " << std::endl;
+		}
+	}
+}
+
+void TuioManager::removeUntouchedStoppedBlobs25D() {
+
+	std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin();
+	while (tuioBlob != blob25DList.end()) {
+		TuioBlob25D *tblb = (*tuioBlob);
+		if ((tblb->getTuioTime() != currentFrameTime) && (!tblb->isMoving())) {
+			removeTuioBlob25D(tblb);
+			tuioBlob = blob25DList.begin();
+		}
+		else tuioBlob++;
+	}
+}
+
+void TuioManager::resetTuioBlobs25D() {
+
+	std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin();
+	while (tuioBlob != blob25DList.end()) {
+		removeTuioBlob25D((*tuioBlob));
+		tuioBlob = blob25DList.begin();
+	}
+}
+
+
+
+
+
+
+
+
+
+
+
+
+TuioObject3D* TuioManager::getClosestTuioObject3D(float xp, float yp, float zp) {
+
+	TuioObject3D *closestObject = NULL;
+	float closestDistance = 1.0f;
+
+	for (std::list<TuioObject3D*>::iterator iter = object3DList.begin(); iter != object3DList.end(); iter++) {
+		float distance = (*iter)->getDistance(xp, yp, zp);
+		if (distance < closestDistance) {
+			closestObject = (*iter);
+			closestDistance = distance;
+		}
+	}
+
+	return closestObject;
+}
+
+TuioCursor3D* TuioManager::getClosestTuioCursor3D(float xp, float yp, float zp) {
+
+	TuioCursor3D *closestCursor = NULL;
+	float closestDistance = 1.0f;
+
+	for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++) {
+		float distance = (*iter)->getDistance(xp, yp, zp);
+		if (distance < closestDistance) {
+			closestCursor = (*iter);
+			closestDistance = distance;
+		}
+	}
+
+	return closestCursor;
+}
+
+TuioBlob3D* TuioManager::getClosestTuioBlob3D(float xp, float yp, float zp) {
+
+	TuioBlob3D *closestBlob = NULL;
+	float closestDistance = 1.0f;
+
+	for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++) {
+		float distance = (*iter)->getDistance(xp, yp, zp);
+		if (distance < closestDistance) {
+			closestBlob = (*iter);
+			closestDistance = distance;
+		}
+	}
+
+	return closestBlob;
+}
+
+std::list<TuioObject3D*> TuioManager::getUntouchedObjects3D() {
+
+	std::list<TuioObject3D*> untouched;
+	for (std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin(); tuioObject != object3DList.end(); tuioObject++) {
+		TuioObject3D *tobj = (*tuioObject);
+		if (tobj->getTuioTime() != currentFrameTime) untouched.push_back(tobj);
+	}
+	return untouched;
+}
+
+void TuioManager::stopUntouchedMovingObjects3D() {
+
+	std::list<TuioObject3D*> untouched;
+	for (std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin(); tuioObject != object3DList.end(); tuioObject++) {
+
+		TuioObject3D *tobj = (*tuioObject);
+		if ((tobj->getTuioTime() != currentFrameTime) && (tobj->isMoving())) {
+			tobj->stop(currentFrameTime);
+			updateObject3D = true;
+			if (verbose)
+				std::cout << "set obj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getRoll() << " " << tobj->getPitch() << " " << tobj->getYaw()
+				<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRollSpeed() << " " << tobj->getPitchSpeed() << " " << tobj->getYawSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+		}
+	}
+}
+
+void TuioManager::removeUntouchedStoppedObjects3D() {
+
+	std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin();
+	while (tuioObject != object3DList.end()) {
+		TuioObject3D *tobj = (*tuioObject);
+		if ((tobj->getTuioTime() != currentFrameTime) && (!tobj->isMoving())) {
+			removeTuioObject3D(tobj);
+			tuioObject = object3DList.begin();
+		}
+		else tuioObject++;
+	}
+}
+
+void TuioManager::resetTuioObjects3D() {
+
+	std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin();
+	while (tuioObject != object3DList.end()) {
+		removeTuioObject3D((*tuioObject));
+		tuioObject = object3DList.begin();
+	}
+}
+
+std::list<TuioCursor3D*> TuioManager::getUntouchedCursors3D() {
+
+	std::list<TuioCursor3D*> untouched;
+	for (std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin(); tuioCursor != cursor3DList.end(); tuioCursor++) {
+		TuioCursor3D *tcur = (*tuioCursor);
+		if (tcur->getTuioTime() != currentFrameTime) untouched.push_back(tcur);
+	}
+	return untouched;
+}
+
+void TuioManager::stopUntouchedMovingCursors3D() {
+
+	std::list<TuioCursor3D*> untouched;
+	for (std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin(); tuioCursor != cursor3DList.end(); tuioCursor++) {
+		TuioCursor3D *tcur = (*tuioCursor);
+		if ((tcur->getTuioTime() != currentFrameTime) && (tcur->isMoving())) {
+			tcur->stop(currentFrameTime);
+			updateCursor3D = true;
+			if (verbose)
+				std::cout << "set cur " << tcur->getCursorID() << " (" << tcur->getSessionID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+				<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+		}
+	}
+}
+
+void TuioManager::removeUntouchedStoppedCursors3D() {
+
+	if (cursor3DList.size() == 0) return;
+	std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin();
+	while (tuioCursor != cursor3DList.end()) {
+		TuioCursor3D *tcur = (*tuioCursor);
+		if ((tcur->getTuioTime() != currentFrameTime) && (!tcur->isMoving())) {
+			removeTuioCursor3D(tcur);
+			tuioCursor = cursor3DList.begin();
+		}
+		else tuioCursor++;
+	}
+}
+
+void TuioManager::resetTuioCursors3D() {
+
+	std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin();
+	while (tuioCursor != cursor3DList.end()) {
+		removeTuioCursor3D((*tuioCursor));
+		tuioCursor = cursor3DList.begin();
+	}
+}
+
+std::list<TuioBlob3D*> TuioManager::getUntouchedBlobs3D() {
+
+	std::list<TuioBlob3D*> untouched;
+	for (std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin(); tuioBlob != blob3DList.end(); tuioBlob++) {
+		TuioBlob3D *tblb = (*tuioBlob);
+		if (tblb->getTuioTime() != currentFrameTime) untouched.push_back(tblb);
+	}
+	return untouched;
+}
+
+void TuioManager::stopUntouchedMovingBlobs3D() {
+
+	std::list<TuioBlob3D*> untouched;
+	for (std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin(); tuioBlob != blob3DList.end(); tuioBlob++) {
+		TuioBlob3D *tblb = (*tuioBlob);
+		if ((tblb->getTuioTime() != currentFrameTime) && (tblb->isMoving())) {
+			tblb->stop(currentFrameTime);
+			updateBlob3D = true;
+			if (verbose)
+				std::cout << "set blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getRoll() << " " << tblb->getPitch() << " " << tblb->getYaw() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getDepth() << " " << tblb->getVolume()
+				<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRollSpeed() << " " << tblb->getPitchSpeed() << " " << tblb->getYawSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << " " << std::endl;
+		}
+	}
+}
+
+void TuioManager::removeUntouchedStoppedBlobs3D() {
+
+	std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin();
+	while (tuioBlob != blob3DList.end()) {
+		TuioBlob3D *tblb = (*tuioBlob);
+		if ((tblb->getTuioTime() != currentFrameTime) && (!tblb->isMoving())) {
+			removeTuioBlob3D(tblb);
+			tuioBlob = blob3DList.begin();
+		}
+		else tuioBlob++;
+	}
+}
+
+void TuioManager::resetTuioBlobs3D() {
+
+	std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin();
+	while (tuioBlob != blob3DList.end()) {
+		removeTuioBlob3D((*tuioBlob));
+		tuioBlob = blob3DList.begin();
 	}
 }

--- a/TUIO/TuioManager.h
+++ b/TUIO/TuioManager.h
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -28,6 +28,14 @@
 #define OBJ_MESSAGE_SIZE 108	// setMessage + fseqMessage size
 #define CUR_MESSAGE_SIZE 88
 #define BLB_MESSAGE_SIZE 116
+
+#define OBJ25D_MESSAGE_SIZE 124	// setMessage + fseqMessage size
+#define CUR25D_MESSAGE_SIZE 104
+#define BLB25D_MESSAGE_SIZE 132
+
+#define OBJ3D_MESSAGE_SIZE 132	// setMessage + fseqMessage size
+#define CUR3D_MESSAGE_SIZE 104
+#define BLB3D_MESSAGE_SIZE 144
 
 namespace TUIO {
 	/**
@@ -234,6 +242,401 @@ namespace TUIO {
 		 */
 		void removeExternalTuioBlob(TuioBlob *tblb);		
 		
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		/**
+		 * Creates a new TuioObject25D based on the given arguments.
+		 * The new TuioObject25D is added to the TuioServer's internal list of active TuioObjects
+		 * and a reference is returned to the caller.
+		 *
+		 * @param	sym	the Symbol ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	a	the angle to assign
+		 * @return	reference to the created TuioObject
+		 */
+		TuioObject25D* addTuioObject25D(int sym, float xp, float yp, float zp, float a);
+
+		/**
+		 * Updates the referenced TuioObject25D based on the given arguments.
+		 *
+		 * @param	tobj	the TuioObject25D to update
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	a	the angle to assign
+		 */
+		void updateTuioObject25D(TuioObject25D *tobj, float xp, float yp, float zp, float a);
+
+		/**
+		 * Removes the referenced TuioObject25D from the TuioServer's internal list of TuioObjects25D
+		 * and deletes the referenced TuioObject25D afterwards
+		 *
+		 * @param	tobj	the TuioObject to remove
+		 */
+		void removeTuioObject25D(TuioObject25D *tobj);
+
+		/**
+		 * Adds an externally managed TuioObject25D to the TuioServer's internal list of active TuioObjects
+		 *
+		 * @param	tobj	the TuioObject25D to add
+		 */
+		void addExternalTuioObject25D(TuioObject25D *tobj);
+
+		/**
+		 * Updates an externally managed TuioObject25D
+		 *
+		 * @param	tobj	the TuioObject25D to update
+		 */
+		void updateExternalTuioObject25D(TuioObject25D *tobj);
+
+		/**
+		 * Removes an externally managed TuioObject25D from the TuioServer's internal list of TuioObjects25D
+		 * The referenced TuioObject25D is not deleted
+		 *
+		 * @param	tobj	the TuioObject25D to update
+		 */
+		void removeExternalTuioObject25D(TuioObject25D *tobj);
+
+		/**
+		 * Creates a new TuioCursor25D based on the given arguments.
+		 * The new TuioCursor25D is added to the TuioServer's internal list of active TuioCursors25D
+		 * and a reference is returned to the caller.
+		 *
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @return	reference to the created TuioCursor
+		 */
+		TuioCursor25D* addTuioCursor25D(float xp, float yp, float zp);
+
+		/**
+		 * Updates the referenced TuioCursor25D based on the given arguments.
+		 *
+		 * @param	tcur	the TuioObject25D to update
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 */
+		void updateTuioCursor25D(TuioCursor25D *tcur, float xp, float yp, float zp);
+
+		/**
+		 * Removes the referenced TuioCursor25D from the TuioServer's internal list of TuioCursors25D
+		 * and deletes the referenced TuioCursor afterwards
+		 *
+		 * @param	tcur	the TuioCursor25D to remove
+		 */
+		void removeTuioCursor25D(TuioCursor25D *tcur);
+
+		/**
+		 * Adds an externally managed TuioCursor25D
+		 *
+		 * @param	tcur	the TuioCursor25D to add
+		 */
+		void addExternalTuioCursor25D(TuioCursor25D *tcur);
+
+		/**
+		 * Updates an externally managed TuioCursor25D
+		 *
+		 * @param	tcur	the TuioCursor25D to update
+		 */
+		void updateExternalTuioCursor25D(TuioCursor25D *tcur);
+
+		/**
+		 * Removes an externally managed TuioCursor from the TuioServer's internal list of TuioCursor
+		 * The referenced TuioCursor is not deleted
+		 *
+		 * @param	tcur	the TuioCursor25D to remove
+		 */
+		void removeExternalTuioCursor25D(TuioCursor25D *tcur);
+
+		/**
+		 * Creates a new TuioBlob25D based on the given arguments.
+		 * The new TuioBlob is added to the TuioServer's internal list of active TuioBlobs
+		 * and a reference is returned to the caller.
+		 *
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	angle	the angle to assign
+		 * @param	width	the width to assign
+		 * @param	height	the height to assign
+		 * @param	area	the area to assign
+		 * @return	reference to the created TuioBlob
+		 */
+		TuioBlob25D* addTuioBlob25D(float xp, float yp, float zp, float angle, float width, float height, float area);
+
+		/**
+		 * Updates the referenced TuioBlob25D based on the given arguments.
+		 *
+		 * @param	tblb	the TuioObject to update
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	angle	the angle to assign
+		 * @param	width	the width to assign
+		 * @param	height	the height to assign
+		 * @param	area	the area to assign
+		 */
+		void updateTuioBlob25D(TuioBlob25D *tblb, float xp, float yp, float zp, float angle, float width, float height, float area);
+
+		/**
+		 * Removes the referenced TuioBlob25D from the TuioServer's internal list of TuioBlobs25D
+		 * and deletes the referenced TuioBlob afterwards
+		 *
+		 * @param	tblb	the TuioBlob25D to remove
+		 */
+		void removeTuioBlob25D(TuioBlob25D *tblb);
+
+		/**
+		 * Updates an externally managed TuioBlob25D
+		 *
+		 * @param	tblb	the TuioBlob25D to update
+		 */
+		void addExternalTuioBlob25D(TuioBlob25D *tblb);
+
+		/**
+		 * Updates an externally managed TuioBlob25D
+		 *
+		 * @param	tblb	the TuioBlob25D to update
+		 */
+		void updateExternalTuioBlob25D(TuioBlob25D *tblb);
+
+		/**
+		 * Removes an externally managed TuioBlob25D from the TuioServer's internal list of TuioBlob25D
+		 * The referenced TuioBlob25D is not deleted
+		 *
+		 * @param	tblb	the TuioBlob25D to remove
+		 */
+		void removeExternalTuioBlob25D(TuioBlob25D *tblb);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		/**
+		 * Creates a new TuioObject3D based on the given arguments.
+		 * The new TuioObject3D is added to the TuioServer's internal list of active TuioObjects
+		 * and a reference is returned to the caller.
+		 *
+		 * @param	sym	the Symbol ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	roll	the roll angle to assign
+		 * @param	pitch	the pitch angle to assign
+		 * @param	yaw	   the yaw angle to assign
+		 * @return	reference to the created TuioObject
+		 */
+		TuioObject3D* addTuioObject3D(int sym, float xp, float yp, float zp, float roll, float pitch, float yaw);
+
+		/**
+		 * Updates the referenced TuioObject3D based on the given arguments.
+		 *
+		 * @param	tobj	the TuioObject3D to update
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	roll	the roll angle to assign
+		 * @param	pitch	the pitch angle to assign
+		 * @param	yaw	   the yaw angle to assign
+		 */
+		void updateTuioObject3D(TuioObject3D *tobj, float xp, float yp, float zp, float roll, float pitch, float yaw);
+
+		/**
+		 * Removes the referenced TuioObject3D from the TuioServer's internal list of TuioObjects3D
+		 * and deletes the referenced TuioObject3D afterwards
+		 *
+		 * @param	tobj	the TuioObject to remove
+		 */
+		void removeTuioObject3D(TuioObject3D *tobj);
+
+		/**
+		 * Adds an externally managed TuioObject3D to the TuioServer's internal list of active TuioObjects
+		 *
+		 * @param	tobj	the TuioObject3D to add
+		 */
+		void addExternalTuioObject3D(TuioObject3D *tobj);
+
+		/**
+		 * Updates an externally managed TuioObject3D
+		 *
+		 * @param	tobj	the TuioObject3D to update
+		 */
+		void updateExternalTuioObject3D(TuioObject3D *tobj);
+
+		/**
+		 * Removes an externally managed TuioObject3D from the TuioServer's internal list of TuioObjects3D
+		 * The referenced TuioObject3D is not deleted
+		 *
+		 * @param	tobj	the TuioObject3D to update
+		 */
+		void removeExternalTuioObject3D(TuioObject3D *tobj);
+
+		/**
+		 * Creates a new TuioCursor3D based on the given arguments.
+		 * The new TuioCursor3D is added to the TuioServer's internal list of active TuioCursors3D
+		 * and a reference is returned to the caller.
+		 *
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @return	reference to the created TuioCursor
+		 */
+		TuioCursor3D* addTuioCursor3D(float xp, float yp, float zp);
+
+		/**
+		 * Updates the referenced TuioCursor3D based on the given arguments.
+		 *
+		 * @param	tcur	the TuioObject3D to update
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 */
+		void updateTuioCursor3D(TuioCursor3D *tcur, float xp, float yp, float zp);
+
+		/**
+		 * Removes the referenced TuioCursor3D from the TuioServer's internal list of TuioCursors3D
+		 * and deletes the referenced TuioCursor afterwards
+		 *
+		 * @param	tcur	the TuioCursor3D to remove
+		 */
+		void removeTuioCursor3D(TuioCursor3D *tcur);
+
+		/**
+		 * Adds an externally managed TuioCursor3D
+		 *
+		 * @param	tcur	the TuioCursor3D to add
+		 */
+		void addExternalTuioCursor3D(TuioCursor3D *tcur);
+
+		/**
+		 * Updates an externally managed TuioCursor3D
+		 *
+		 * @param	tcur	the TuioCursor3D to update
+		 */
+		void updateExternalTuioCursor3D(TuioCursor3D *tcur);
+
+		/**
+		 * Removes an externally managed TuioCursor from the TuioServer's internal list of TuioCursor
+		 * The referenced TuioCursor is not deleted
+		 *
+		 * @param	tcur	the TuioCursor3D to remove
+		 */
+		void removeExternalTuioCursor3D(TuioCursor3D *tcur);
+
+		/**
+		 * Creates a new TuioBlob3D based on the given arguments.
+		 * The new TuioBlob is added to the TuioServer's internal list of active TuioBlobs
+		 * and a reference is returned to the caller.
+		 *
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	roll	the roll angle to assign
+		 * @param	pitch	the pitch angle to assign
+		 * @param	yaw	   the yaw angle to assign
+		 * @param	width	the width to assign
+		 * @param	height	the height to assign
+		 * @param	depth	the depth to assign
+		 * @param	volume	the volume to assign
+		 * @return	reference to the created TuioBlob
+		 */
+		TuioBlob3D* addTuioBlob3D(float xp, float yp, float zp, float roll, float pitch, float yaw, float width, float height, float depth, float volume);
+
+		/**
+		 * Updates the referenced TuioBlob3D based on the given arguments.
+		 *
+		 * @param	tblb	the TuioObject to update
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	roll	the roll angle to assign
+		 * @param	pitch	the pitch angle to assign
+		 * @param	yaw	   the yaw angle to assign
+		 * @param	width	the width to assign
+		 * @param	height	the height to assign
+		 * @param	depth	the depth to assign
+		 * @param	volume	the volume to assign
+		 */
+		void updateTuioBlob3D(TuioBlob3D *tblb, float xp, float yp, float zp, float roll, float pitch, float yaw, float width, float height, float depth, float volume);
+
+		/**
+		 * Removes the referenced TuioBlob3D from the TuioServer's internal list of TuioBlobs3D
+		 * and deletes the referenced TuioBlob afterwards
+		 *
+		 * @param	tblb	the TuioBlob3D to remove
+		 */
+		void removeTuioBlob3D(TuioBlob3D *tblb);
+
+		/**
+		 * Updates an externally managed TuioBlob3D
+		 *
+		 * @param	tblb	the TuioBlob3D to update
+		 */
+		void addExternalTuioBlob3D(TuioBlob3D *tblb);
+
+		/**
+		 * Updates an externally managed TuioBlob3D
+		 *
+		 * @param	tblb	the TuioBlob3D to update
+		 */
+		void updateExternalTuioBlob3D(TuioBlob3D *tblb);
+
+		/**
+		 * Removes an externally managed TuioBlob3D from the TuioServer's internal list of TuioBlob3D
+		 * The referenced TuioBlob3D is not deleted
+		 *
+		 * @param	tblb	the TuioBlob3D to remove
+		 */
+		void removeExternalTuioBlob3D(TuioBlob3D *tblb);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 		/**
 		 * Initializes a new frame with the given TuioTime
 		 *
@@ -340,6 +743,182 @@ namespace TUIO {
 		 */
 		TuioBlob* getClosestTuioBlob(float xp, float yp);
 		
+
+
+
+
+
+
+		/**
+		 * Returns a List of all currently inactive TuioObjects25D
+		 *
+		 * @return  a List of all currently inactive TuioObjects25D
+		 */
+		std::list<TuioObject25D*> getUntouchedObjects25D();
+
+		/**
+		 * Returns a List of all currently inactive TuioCursors25D
+		 *
+		 * @return  a List of all currently inactive TuioCursors25D
+		 */
+		std::list<TuioCursor25D*> getUntouchedCursors25D();
+
+		/**
+		 * Returns a List of all currently inactive TuioBlobs25D
+		 *
+		 * @return  a List of all currently inactive TuioBlobs25D
+		 */
+		std::list<TuioBlob25D*> getUntouchedBlobs25D();
+
+		/**
+		 * Calculates speed and acceleration values for all currently inactive TuioObjects25D
+		 */
+		void stopUntouchedMovingObjects25D();
+
+		/**
+		 * Calculates speed and acceleration values for all currently inactive TuioCursors25D
+		 */
+		void stopUntouchedMovingCursors25D();
+
+		/**
+		 * Calculates speed and acceleration values for all currently inactive TuioBlobs25D
+		 */
+		void stopUntouchedMovingBlobs25D();
+
+		/**
+		 * Removes all currently inactive TuioObjects from the TuioServer's internal list of TuioObjects25D
+		 */
+		void removeUntouchedStoppedObjects25D();
+
+		/**
+		 * Removes all currently inactive TuioCursors from the TuioServer's internal list of TuioCursors25D
+		 */
+		void removeUntouchedStoppedCursors25D();
+
+		/**
+		 * Removes all currently inactive TuioCursors from the TuioServer's internal list of TuioBlobs25D
+		 */
+		void removeUntouchedStoppedBlobs25D();
+
+		/**
+		 * Returns the TuioObject25D closest to the provided coordinates
+		 * or NULL if there isn't any active TuioObject25D
+		 *
+		 * @return  the closest TuioObject25D to the provided coordinates or NULL
+		 */
+		TuioObject25D* getClosestTuioObject25D(float xp, float yp, float zp);
+
+		/**
+		 * Returns the TuioCursor25D closest to the provided coordinates
+		 * or NULL if there isn't any active TuioCursor25D
+		 *
+		 * @return  the closest TuioCursor25D corresponding to the provided coordinates or NULL
+		 */
+		TuioCursor25D* getClosestTuioCursor25D(float xp, float yp, float zp);
+
+		/**
+		 * Returns the TuioBlob25D closest to the provided coordinates
+		 * or NULL if there isn't any active TuioBlob25D
+		 *
+		 * @return  the closest TuioBlob25D corresponding to the provided coordinates or NULL
+		 */
+		TuioBlob25D* getClosestTuioBlob25D(float xp, float yp, float zp);
+
+
+
+
+
+		/**
+		 * Returns a List of all currently inactive TuioObjects3D
+		 *
+		 * @return  a List of all currently inactive TuioObjects3D
+		 */
+		std::list<TuioObject3D*> getUntouchedObjects3D();
+
+		/**
+		 * Returns a List of all currently inactive TuioCursors3D
+		 *
+		 * @return  a List of all currently inactive TuioCursors3D
+		 */
+		std::list<TuioCursor3D*> getUntouchedCursors3D();
+
+		/**
+		 * Returns a List of all currently inactive TuioBlobs3D
+		 *
+		 * @return  a List of all currently inactive TuioBlobs3D
+		 */
+		std::list<TuioBlob3D*> getUntouchedBlobs3D();
+
+		/**
+		 * Calculates speed and acceleration values for all currently inactive TuioObjects3D
+		 */
+		void stopUntouchedMovingObjects3D();
+
+		/**
+		 * Calculates speed and acceleration values for all currently inactive TuioCursors3D
+		 */
+		void stopUntouchedMovingCursors3D();
+
+		/**
+		 * Calculates speed and acceleration values for all currently inactive TuioBlobs3D
+		 */
+		void stopUntouchedMovingBlobs3D();
+
+		/**
+		 * Removes all currently inactive TuioObjects from the TuioServer's internal list of TuioObjects3D
+		 */
+		void removeUntouchedStoppedObjects3D();
+
+		/**
+		 * Removes all currently inactive TuioCursors from the TuioServer's internal list of TuioCursors3D
+		 */
+		void removeUntouchedStoppedCursors3D();
+
+		/**
+		 * Removes all currently inactive TuioCursors from the TuioServer's internal list of TuioBlobs3D
+		 */
+		void removeUntouchedStoppedBlobs3D();
+
+		/**
+		 * Returns the TuioObject3D closest to the provided coordinates
+		 * or NULL if there isn't any active TuioObject3D
+		 *
+		 * @return  the closest TuioObject3D to the provided coordinates or NULL
+		 */
+		TuioObject3D* getClosestTuioObject3D(float xp, float yp, float zp);
+
+		/**
+		 * Returns the TuioCursor3D closest to the provided coordinates
+		 * or NULL if there isn't any active TuioCursor3D
+		 *
+		 * @return  the closest TuioCursor3D corresponding to the provided coordinates or NULL
+		 */
+		TuioCursor3D* getClosestTuioCursor3D(float xp, float yp, float zp);
+
+		/**
+		 * Returns the TuioBlob3D closest to the provided coordinates
+		 * or NULL if there isn't any active TuioBlob3D
+		 *
+		 * @return  the closest TuioBlob3D corresponding to the provided coordinates or NULL
+		 */
+		TuioBlob3D* getClosestTuioBlob3D(float xp, float yp, float zp);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 		/**
 		 * The TuioServer prints verbose TUIO event messages to the console if set to true.
 		 * @param	verbose	print verbose messages if set to true
@@ -351,39 +930,90 @@ namespace TUIO {
 			invert_x = ix; 
 			invert_y = iy; 
 			invert_a = ia; 
+		};		
+		
+		void setInversion(bool ix, bool iy, bool iz, bool ia, bool ib, bool ic) {
+			invert_x = ix;
+			invert_y = iy;
+			invert_z = iz;
+			invert_a = ia;
+			invert_b = ib;
+			invert_c = ic;
 		};
 
 		void setInvertXpos(bool ix) { invert_x = ix; };
 		void setInvertYpos(bool iy) { invert_y = iy; };
+		void setInvertZpos(bool iz) { invert_z = iz; };
 		void setInvertAngle(bool ia) { invert_a = ia; };
+		void setInvertRoll(bool ir) { invert_a = ir; };
+		void setInvertPitch(bool ip) { invert_b = ip; };
+		void setInvertYaw(bool iy) { invert_c = iy; };
 		bool getInvertXpos() { return invert_x; };
 		bool getInvertYpos() { return invert_y; };
+		bool getInvertZpos() { return invert_z; };
 		bool getInvertAngle() { return invert_a; };
+		bool getInvertRoll() { return invert_a; };
+		bool getInvertPitch() { return invert_b; };
+		bool getInvertYaw() { return invert_c; };
 		void resetTuioObjects();
 		void resetTuioCursors();		
-		void resetTuioBlobs();		
+		void resetTuioBlobs();
+		void resetTuioObjects25D();
+		void resetTuioCursors25D();
+		void resetTuioBlobs25D();
+		void resetTuioObjects3D();
+		void resetTuioCursors3D();
+		void resetTuioBlobs3D();
 		
 	protected:
+
+		// freeList and freeBuffer are nor appliable on Object because they have their own ids
+
 		std::list<TuioCursor*> freeCursorList;
 		std::list<TuioCursor*> freeCursorBuffer;
 
 		std::list<TuioBlob*> freeBlobList;
 		std::list<TuioBlob*> freeBlobBuffer;
 
+		std::list<TuioCursor25D*> freeCursor25DList;
+		std::list<TuioCursor25D*> freeCursor25DBuffer;
+
+		std::list<TuioBlob25D*> freeBlob25DList;
+		std::list<TuioBlob25D*> freeBlob25DBuffer;
+
+		std::list<TuioCursor3D*> freeCursor3DList;
+		std::list<TuioCursor3D*> freeCursor3DBuffer;
+
+		std::list<TuioBlob3D*> freeBlob3DList;
+		std::list<TuioBlob3D*> freeBlob3DBuffer;
+
 		TuioTime currentFrameTime;
 		long currentFrame;
 		int maxCursorID;
 		int maxBlobID;
+		int maxCursor25DID;
+		int maxBlob25DID;
+		int maxCursor3DID;
+		int maxBlob3DID;
 		long sessionID;
 
 		bool updateObject;
 		bool updateCursor;
 		bool updateBlob;
+		bool updateObject25D;
+		bool updateCursor25D;
+		bool updateBlob25D;
+		bool updateObject3D;
+		bool updateCursor3D;
+		bool updateBlob3D;
 		bool verbose;
 
 		bool invert_x;
 		bool invert_y;
+		bool invert_z;
 		bool invert_a;
+		bool invert_b;
+		bool invert_c;
 	};
 }
 #endif /* INCLUDED_TUIOMANAGER_H */

--- a/TUIO/TuioManager.h
+++ b/TUIO/TuioManager.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -65,7 +66,7 @@ namespace TUIO {
 	 * </code></p>
 	 *
 	 * @author Martin Kaltenbrunner
-	 * @version 1.1.6
+	 * @version 1.1.7
 	 */ 
 	class LIBDECL TuioManager : public TuioDispatcher { 
 	

--- a/TUIO/TuioObject.cpp
+++ b/TUIO/TuioObject.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioObject.cpp
+++ b/TUIO/TuioObject.cpp
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -21,7 +21,7 @@
 
 using namespace TUIO;
 
-TuioObject::TuioObject (TuioTime ttime, long si, int sym, float xp, float yp, float a):TuioContainer(ttime, si, xp, yp) {
+TuioObject::TuioObject (TuioTime ttime, long si, int sym, float xp, float yp, float a):TuioContainer(ttime, si, xp, yp, 0) {
 	symbol_id = sym;
 	angle = a;
 	rotation_speed = 0.0f;
@@ -31,7 +31,7 @@ TuioObject::TuioObject (TuioTime ttime, long si, int sym, float xp, float yp, fl
 	angleThreshold = 0.0f;
 }
 
-TuioObject::TuioObject (long si, int sym, float xp, float yp, float a):TuioContainer(si, xp, yp) {
+TuioObject::TuioObject (long si, int sym, float xp, float yp, float a):TuioContainer(si, xp, yp, 0) {
 	symbol_id = sym;
 	angle = a;
 	rotation_speed = 0.0f;
@@ -52,7 +52,7 @@ TuioObject::TuioObject (TuioObject *tobj):TuioContainer(tobj) {
 }
 
 void TuioObject::update (TuioTime ttime, float xp, float yp, float a, float xs, float ys, float rs, float ma, float ra) {
-	TuioContainer::update(ttime,xp,yp,xs,ys,ma);
+	TuioContainer::update(ttime,xp,yp,0,xs,ys,0,ma);
 	angle = a;
 	rotation_speed = rs;
 	rotation_accel = ra;
@@ -61,7 +61,7 @@ void TuioObject::update (TuioTime ttime, float xp, float yp, float a, float xs, 
 
 
 void TuioObject::update (float xp, float yp, float a, float xs, float ys, float rs, float ma, float ra) {
-	TuioContainer::update(xp,yp,xs,ys,ma);
+	TuioContainer::update(xp,yp,0,xs,ys,0,ma);
 	angle = a;
 	rotation_speed = rs;
 	rotation_accel = ra;
@@ -70,7 +70,7 @@ void TuioObject::update (float xp, float yp, float a, float xs, float ys, float 
 
 void TuioObject::update (TuioTime ttime, float xp, float yp, float a) {
 	TuioPoint lastPoint = path.back();
-	TuioContainer::update(ttime,xp,yp);
+	TuioContainer::update(ttime,xp,yp,0);
 	
 	TuioTime diffTime = currentTime - lastPoint.getTuioTime();
 	float dt = diffTime.getTotalMilliseconds()/1000.0f;

--- a/TUIO/TuioObject25D.cpp
+++ b/TUIO/TuioObject25D.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioObject by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioObject25D.cpp
+++ b/TUIO/TuioObject25D.cpp
@@ -1,0 +1,157 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#include "TuioObject25D.h"
+#include <iostream>
+
+using namespace TUIO;
+
+TuioObject25D::TuioObject25D(TuioTime ttime, long si, int sym, float xp, float yp, float zp, float a) :TuioContainer(ttime, si, xp, yp, zp) {
+	symbol_id = sym;
+	angle = a;
+	rotation_speed = 0.0f;
+	rotation_accel = 0.0f;
+
+	angleFilter = NULL;
+	angleThreshold = 0.0f;
+}
+
+TuioObject25D::TuioObject25D(long si, int sym, float xp, float yp, float zp, float a) :TuioContainer(si, xp, yp, zp) {
+	symbol_id = sym;
+	angle = a;
+	rotation_speed = 0.0f;
+	rotation_accel = 0.0f;
+
+	angleFilter = NULL;
+	angleThreshold = 0.0f;
+}
+
+TuioObject25D::TuioObject25D(TuioObject25D *tobj) :TuioContainer(tobj) {
+	symbol_id = tobj->getSymbolID();
+	angle = tobj->getAngle();
+	rotation_speed = 0.0f;
+	rotation_accel = 0.0f;
+
+	angleFilter = NULL;
+	angleThreshold = 0.0f;
+}
+
+void TuioObject25D::update(TuioTime ttime, float xp, float yp, float zp, float a, float xs, float ys, float zs, float rs, float ma, float ra) {
+	TuioContainer::update(ttime, xp, yp, zp, xs, ys, zs, ma);
+	angle = a;
+	rotation_speed = rs;
+	rotation_accel = ra;
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+}
+
+
+void TuioObject25D::update(float xp, float yp, float zp, float a, float xs, float ys, float zs, float rs, float ma, float ra) {
+	TuioContainer::update(xp, yp, zp, xs, ys, zs, ma);
+	angle = a;
+	rotation_speed = rs;
+	rotation_accel = ra;
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+}
+
+void TuioObject25D::update(TuioTime ttime, float xp, float yp, float zp, float a) {
+	TuioPoint lastPoint = path.back();
+	TuioContainer::update(ttime, xp, yp, zp);
+
+	TuioTime diffTime = currentTime - lastPoint.getTuioTime();
+	float dt = diffTime.getTotalMilliseconds() / 1000.0f;
+	float last_rotation_speed = rotation_speed;
+
+	float da = a - angle;
+	if (da > M_PI) da -= 2 * M_PI;
+	else if (da < -M_PI) da += 2 * M_PI;
+
+	float prev_angle = angle;
+	if (angleFilter) angle = angleFilter->filter(angle + da, dt);
+	else angle = angle + da;
+	if (fabs(angle - prev_angle) < angleThreshold) angle = prev_angle;
+
+	if (angle > 2 * M_PI) angle -= 2 * M_PI;
+	else if (angle < 0) angle += 2 * M_PI;
+
+	da = angle - prev_angle;
+	if (da > M_PI) da -= 2 * M_PI;
+	else if (da < -M_PI) da += 2 * M_PI;
+	da = da / (2 * M_PI);
+
+	rotation_speed = (float)da / dt;
+	rotation_accel = (rotation_speed - last_rotation_speed) / dt;
+
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+}
+
+void TuioObject25D::stop(TuioTime ttime) {
+	update(ttime, xpos, ypos, zpos, angle);
+}
+
+void TuioObject25D::update(TuioObject25D *tobj) {
+	TuioContainer::update(tobj);
+	angle = tobj->getAngle();
+	rotation_speed = tobj->getRotationSpeed();
+	rotation_accel = tobj->getRotationAccel();
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+}
+
+int TuioObject25D::getSymbolID() const {
+	return symbol_id;
+}
+
+float TuioObject25D::getAngle() const {
+	return angle;
+}
+
+float TuioObject25D::getAngleDegrees() const {
+	return (float)(angle / M_PI * 180);
+}
+
+float TuioObject25D::getRotationSpeed() const {
+	return rotation_speed;
+}
+
+float TuioObject25D::getRotationAccel() const {
+	return rotation_accel;
+}
+
+bool TuioObject25D::isMoving() const {
+	if ((state == TUIO_ACCELERATING) || (state == TUIO_DECELERATING) || (state == TUIO_ROTATING)) return true;
+	else return false;
+}
+
+void TuioObject25D::addAngleThreshold(float thresh) {
+	angleThreshold = thresh;
+}
+
+void TuioObject25D::removeAngleThreshold() {
+	angleThreshold = 0.0f;
+}
+
+void TuioObject25D::addAngleFilter(float mcut, float beta) {
+
+	if (angleFilter) delete angleFilter;
+	angleFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioObject25D::removeAngleFilter() {
+
+	if (angleFilter) delete angleFilter;
+	angleFilter = NULL;
+}

--- a/TUIO/TuioObject25D.h
+++ b/TUIO/TuioObject25D.h
@@ -1,0 +1,210 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#ifndef INCLUDED_TUIOOBJECT25D_H
+#define INCLUDED_TUIOOBJECT25D_H
+
+#include "TuioContainer.h"
+
+namespace TUIO {
+
+	/**
+	 * The TuioObject2.5D class encapsulates /tuio/25Dobj TUIO objects.
+	 *
+	 * @author Nicolas Bremard 
+	 * @version 1.1.7
+	 */
+	class LIBDECL TuioObject25D : public TuioContainer {
+
+	protected:
+		/**
+		 * The individual symbol ID number that is assigned to each TuioObject.
+		 */
+		int symbol_id;
+		/**
+		 * The rotation angle value.
+		 */
+		float angle;
+		/**
+		 * The rotation speed value.
+		 */
+		float rotation_speed;
+		/**
+		 * The rotation acceleration value.
+		 */
+		float rotation_accel;
+
+		float angleThreshold;
+		OneEuroFilter *angleFilter;
+
+	public:
+		using TuioContainer::update;
+
+		/**
+		 * This constructor takes a TuioTime argument and assigns it along with the provided
+		 * Session ID, Symbol ID, X and Y coordinate and angle to the newly created TuioObject.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	si	the Session ID  to assign
+		 * @param	sym	the Symbol ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	a	the angle to assign
+		 */
+		TuioObject25D(TuioTime ttime, long si, int sym, float xp, float yp, float zp, float a);
+
+		/**
+		 * This constructor takes the provided Session ID, Symbol ID, X and Y coordinate
+		 * and angle, and assigs these values to the newly created TuioObject.
+		 *
+		 * @param	si	the Session ID  to assign
+		 * @param	sym	the Symbol ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	a	the angle to assign
+		 */
+		TuioObject25D(long si, int sym, float xp, float yp, float zp, float a);
+
+		/**
+		 * This constructor takes the atttibutes of the provided TuioObject
+		 * and assigs these values to the newly created TuioObject.
+		 *
+		 * @param	tobj	the TuioObject to assign
+		 */
+		TuioObject25D(TuioObject25D *tobj);
+
+		/**
+		 * The destructor is doing nothing in particular.
+		 */
+		virtual ~TuioObject25D() {
+			if (angleFilter) delete angleFilter;
+		};
+
+		/**
+		 * Takes a TuioTime argument and assigns it along with the provided
+		 * X and Y coordinate, angle, X and Y velocity, motion acceleration,
+		 * rotation speed and rotation acceleration to the private TuioObject attributes.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	a	the angle coordinate to assign
+		 * @param	xs	the X velocity to assign
+		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
+		 * @param	rs	the rotation velocity to assign
+		 * @param	ma	the motion acceleration to assign
+		 * @param	ra	the rotation acceleration to assign
+		 */
+		void update(TuioTime ttime, float xp, float yp, float zp, float a, float xs, float ys, float zs, float rs, float ma, float ra);
+
+		/**
+		 * Assigns the provided X and Y coordinate, angle, X and Y velocity, motion acceleration
+		 * rotation velocity and rotation acceleration to the private TuioContainer attributes.
+		 * The TuioTime time stamp remains unchanged.
+		 *
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	a	the angle coordinate to assign
+		 * @param	xs	the X velocity to assign
+		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
+		 * @param	rs	the rotation velocity to assign
+		 * @param	ma	the motion acceleration to assign
+		 * @param	ra	the rotation acceleration to assign
+		 */
+		void update(float xp, float yp, float zp, float a, float xs, float ys, float zs, float rs, float ma, float ra);
+
+		/**
+		 * Takes a TuioTime argument and assigns it along with the provided
+		 * X and Y coordinate and angle to the private TuioObject attributes.
+		 * The speed and accleration values are calculated accordingly.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	a	the angle coordinate to assign
+		 */
+		void update(TuioTime ttime, float xp, float yp, float zp, float a);
+
+		/**
+		 * This method is used to calculate the speed and acceleration values of a
+		 * TuioObject with unchanged position and angle.
+		 */
+		void stop(TuioTime ttime);
+
+		/**
+		 * Takes the atttibutes of the provided TuioObject
+		 * and assigs these values to this TuioObject.
+		 * The TuioTime time stamp of this TuioContainer remains unchanged.
+		 *
+		 * @param	tobj	the TuioContainer to assign
+		 */
+		void update(TuioObject25D *tobj);
+
+		/**
+		 * Returns the symbol ID of this TuioObject.
+		 * @return	the symbol ID of this TuioObject
+		 */
+		int getSymbolID() const;
+
+		/**
+		 * Returns the rotation angle of this TuioObject.
+		 * @return	the rotation angle of this TuioObject
+		 */
+		float getAngle() const;
+
+		/**
+		 * Returns the rotation angle in degrees of this TuioObject.
+		 * @return	the rotation angle in degrees of this TuioObject
+		 */
+		float getAngleDegrees() const;
+
+		/**
+		 * Returns the rotation speed of this TuioObject.
+		 * @return	the rotation speed of this TuioObject
+		 */
+		float getRotationSpeed() const;
+
+		/**
+		 * Returns the rotation acceleration of this TuioObject.
+		 * @return	the rotation acceleration of this TuioObject
+		 */
+		float getRotationAccel() const;
+
+		/**
+		 * Returns true of this TuioObject is moving.
+		 * @return	true of this TuioObject is moving
+		 */
+		bool isMoving() const;
+
+		void addAngleThreshold(float thresh);
+
+		void removeAngleThreshold();
+
+		void addAngleFilter(float mcut, float beta);
+
+		void removeAngleFilter();
+	};
+}
+#endif

--- a/TUIO/TuioObject25D.h
+++ b/TUIO/TuioObject25D.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioObject by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioObject3D.cpp
+++ b/TUIO/TuioObject3D.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioObject by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioObject3D.cpp
+++ b/TUIO/TuioObject3D.cpp
@@ -1,0 +1,339 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#include "TuioObject3D.h"
+#include <iostream>
+
+using namespace TUIO;
+
+TuioObject3D::TuioObject3D(TuioTime ttime, long si, int sym, float xp, float yp, float zp, float ro, float po, float yo) :TuioContainer(ttime, si, xp, yp, zp) {
+	symbol_id = sym;
+	roll = ro;
+	pitch = po;
+	yaw = yo;
+	roll_speed = 0.0f;
+	pitch_speed = 0.0f;
+	yaw_speed = 0.0f;
+	roll_accel = 0.0f;
+	pitch_accel = 0.0f;
+	yaw_accel = 0.0f;
+	rotation_accel = 0.0f;
+
+	rollFilter = NULL;
+	pitchFilter = NULL;
+	yawFilter = NULL;
+	rollThreshold = 0.0f;
+	pitchThreshold = 0.0f;
+	yawThreshold = 0.0f;
+}
+
+TuioObject3D::TuioObject3D(long si, int sym, float xp, float yp, float zp, float ro, float po, float yo) :TuioContainer(si, xp, yp, zp) {
+	symbol_id = sym;
+	roll = ro;
+	pitch = po;
+	yaw = yo;
+	roll_speed = 0.0f;
+	pitch_speed = 0.0f;
+	yaw_speed = 0.0f;
+	roll_accel = 0.0f;
+	pitch_accel = 0.0f;
+	yaw_accel = 0.0f;
+	rotation_accel = 0.0f;
+
+	rollFilter = NULL;
+	pitchFilter = NULL;
+	yawFilter = NULL;
+	rollThreshold = 0.0f;
+	pitchThreshold = 0.0f;
+	yawThreshold = 0.0f;
+}
+
+TuioObject3D::TuioObject3D(TuioObject3D *tobj) :TuioContainer(tobj) {
+	symbol_id = tobj->getSymbolID();
+
+	roll = tobj->getRoll();
+	pitch = tobj->getPitch();
+	yaw = tobj->getYaw();
+	roll_speed = tobj->getRollSpeed();
+	pitch_speed = tobj->getPitchSpeed();
+	yaw_speed = tobj->getYawSpeed();
+	roll_accel = tobj->getRollAccel();
+	pitch_accel = tobj->getPitchAccel();
+	yaw_accel = tobj->getYawAccel();
+	rotation_accel = tobj->getRotationAccel();
+
+	rollFilter = NULL;
+	pitchFilter = NULL;
+	yawFilter = NULL;
+	rollThreshold = 0.0f;
+	pitchThreshold = 0.0f;
+	yawThreshold = 0.0f;
+
+	rollFilter = NULL;
+	pitchFilter = NULL;
+	yawFilter = NULL;
+	rollThreshold = 0.0f;
+	pitchThreshold = 0.0f;
+	yawThreshold = 0.0f;
+}
+
+void TuioObject3D::update(TuioTime ttime, float xp, float yp, float zp, float ro, float po, float yo, float xs, float ys, float zs, float ros, float pos, float yos, float ma, float ra) {
+	TuioContainer::update(ttime, xp, yp, zp, xs, ys, zs, ma);
+	roll = ro;
+	pitch = po;
+	yaw = yo;
+	roll_speed = ros;
+	yaw_speed = pos;
+	pitch_speed = yos;
+	rotation_accel = ra;
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+}
+
+
+void TuioObject3D::update(float xp, float yp, float zp, float ro, float po, float yo, float xs, float ys, float zs, float ros, float pos, float yos, float ma, float ra) {
+	TuioContainer::update(xp, yp, zp, xs, ys, zs, ma);
+	roll = ro;
+	pitch = po;
+	yaw = yo;
+	roll_speed = ros;
+	yaw_speed = pos;
+	pitch_speed = yos;
+	rotation_accel = ra;
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+}
+
+void TuioObject3D::update(TuioTime ttime, float xp, float yp, float zp, float ro, float po, float yo) {
+	TuioPoint lastPoint = path.back();
+	TuioContainer::update(ttime, xp, yp, zp);
+
+	TuioTime diffTime = currentTime - lastPoint.getTuioTime();
+	float dt = diffTime.getTotalMilliseconds() / 1000.0f;
+
+
+	float last_roll_speed = roll_speed;
+	float dr = ro - roll;
+	if (dr > M_PI) dr -= 2 * M_PI;
+	else if (dr < -M_PI) dr += 2 * M_PI;
+
+	float prev_roll = roll;
+	if (rollFilter) roll = rollFilter->filter(roll + dr, dt);
+	else roll = roll + dr;
+	if (fabs(roll - prev_roll) < rollThreshold) roll = prev_roll;
+
+	if (roll > 2 * M_PI) roll -= 2 * M_PI;
+	else if (roll < 0) roll += 2 * M_PI;
+
+	dr = roll - prev_roll;
+	if (dr > M_PI) dr -= 2 * M_PI;
+	else if (dr < -M_PI) dr += 2 * M_PI;
+	dr = dr / (2 * M_PI);
+
+	roll_speed = (float)dr / dt;
+	roll_accel = (roll_speed - last_roll_speed) / dt;
+
+
+	float last_pitch_speed = pitch_speed;
+	float dp = po - pitch;
+	if (dp > M_PI) dp -= 2 * M_PI;
+	else if (dp < -M_PI) dp += 2 * M_PI;
+
+	float prev_pitch = pitch;
+	if (pitchFilter) pitch = pitchFilter->filter(pitch + dp, dt);
+	else pitch = pitch + dp;
+	if (fabs(pitch - prev_pitch) < pitchThreshold) pitch = prev_pitch;
+
+	if (pitch > 2 * M_PI) pitch -= 2 * M_PI;
+	else if (pitch < 0) pitch += 2 * M_PI;
+
+	dp = pitch - prev_pitch;
+	if (dp > M_PI) dp -= 2 * M_PI;
+	else if (dp < -M_PI) dp += 2 * M_PI;
+	dp = dp / (2 * M_PI);
+
+	pitch_speed = (float)dp / dt;
+	pitch_accel = (pitch_speed - last_pitch_speed) / dt;
+
+
+	float last_yaw_speed = yaw_speed;
+	float dy = yo - yaw;
+	if (dy > M_PI) dy -= 2 * M_PI;
+	else if (dy < -M_PI) dy += 2 * M_PI;
+
+	float prev_yaw = yaw;
+	if (yawFilter) yaw = yawFilter->filter(yaw + dy, dt);
+	else yaw = yaw + dy;
+	if (fabs(yaw - prev_yaw) < yawThreshold) yaw = prev_yaw;
+
+	if (yaw > 2 * M_PI) yaw -= 2 * M_PI;
+	else if (yaw < 0) yaw += 2 * M_PI;
+
+	dy = yaw - prev_yaw;
+	if (dy > M_PI) dy -= 2 * M_PI;
+	else if (dy < -M_PI) dy += 2 * M_PI;
+	dy = dy / (2 * M_PI);
+
+	yaw_speed = (float)dy / dt;
+	yaw_accel = (yaw_speed - last_yaw_speed) / dt;
+
+
+	rotation_accel = (roll_accel + pitch_accel + yaw_accel ) / 3;
+
+	if (((roll != 0)|| (pitch != 0)|| (yaw != 0)) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+}
+
+void TuioObject3D::stop(TuioTime ttime) {
+	update(ttime, xpos, ypos, zpos);
+}
+
+void TuioObject3D::update(TuioObject3D *tobj) {
+	TuioContainer::update(tobj);
+
+	roll = tobj->getRoll();
+	pitch = tobj->getPitch();
+	yaw = tobj->getYaw();
+	roll_speed = tobj->getRollSpeed();
+	pitch_speed = tobj->getPitchSpeed();
+	yaw_speed = tobj->getYawSpeed();
+	roll_accel = tobj->getRollAccel();
+	pitch_accel = tobj->getPitchAccel();
+	yaw_accel = tobj->getYawAccel();
+	rotation_accel = tobj->getRotationAccel();
+
+	if ((rotation_accel != 0) && (state == TUIO_STOPPED)) state = TUIO_ROTATING;
+}
+
+int TuioObject3D::getSymbolID() const {
+	return symbol_id;
+}
+
+float TuioObject3D::getRoll() const {
+	return roll;
+}
+
+float TuioObject3D::getRollDegrees() const {
+	return (float)(roll / M_PI * 180);
+}
+
+float TuioObject3D::getRollSpeed() const {
+	return roll_speed;
+}
+
+float TuioObject3D::getRollAccel() const {
+	return roll_accel;
+}
+
+float TuioObject3D::getPitch() const {
+	return pitch;
+}
+
+float TuioObject3D::getPitchDegrees() const {
+	return (float)(pitch / M_PI * 180);
+}
+
+float TuioObject3D::getPitchSpeed() const {
+	return pitch_speed;
+}
+
+float TuioObject3D::getPitchAccel() const {
+	return pitch_accel;
+}
+
+float TuioObject3D::getYaw() const {
+	return yaw;
+}
+
+float TuioObject3D::getYawDegrees() const {
+	return (float)(yaw / M_PI * 180);
+}
+
+float TuioObject3D::getYawSpeed() const {
+	return yaw_speed;
+}
+
+float TuioObject3D::getYawAccel() const {
+	return yaw_accel;
+}
+
+float TuioObject3D::getRotationAccel() const {
+	return rotation_accel;
+}
+
+bool TuioObject3D::isMoving() const {
+	if ((state == TUIO_ACCELERATING) || (state == TUIO_DECELERATING) || (state == TUIO_ROTATING)) return true;
+	else return false;
+}
+
+void TuioObject3D::addRollThreshold(float thresh) {
+	rollThreshold = thresh;
+}
+
+void TuioObject3D::addPitchThreshold(float thresh) {
+	pitchThreshold = thresh;
+}
+
+void TuioObject3D::addYawThreshold(float thresh) {
+	yawThreshold = thresh;
+}
+
+
+void TuioObject3D::removeRollThreshold() {
+	rollThreshold = 0.0f;
+}
+
+void TuioObject3D::removePitchThreshold() {
+	pitchThreshold = 0.0f;
+}
+
+void TuioObject3D::removeYawThreshold() {
+	yawThreshold = 0.0f;
+}
+void TuioObject3D::addRollFilter(float mcut, float beta) {
+
+	if (rollFilter) delete rollFilter;
+	rollFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioObject3D::addPitchFilter(float mcut, float beta) {
+
+	if (pitchFilter) delete pitchFilter;
+	pitchFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioObject3D::addYawFilter(float mcut, float beta) {
+
+	if (yawFilter) delete yawFilter;
+	yawFilter = new OneEuroFilter(60.0f, mcut, beta, 10.0f);
+}
+
+void TuioObject3D::removeRollFilter() {
+
+	if (rollFilter) delete rollFilter;
+	rollFilter = NULL;
+}
+
+void TuioObject3D::removePitchFilter() {
+
+	if (pitchFilter) delete pitchFilter;
+	pitchFilter = NULL;
+}
+
+void TuioObject3D::removeYawFilter() {
+
+	if (yawFilter) delete yawFilter;
+	yawFilter = NULL;
+}

--- a/TUIO/TuioObject3D.h
+++ b/TUIO/TuioObject3D.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2022 Nicolas Bremard <nicolas@bremard.fr>
+ Based on TuioObject by Martin Kaltenbrunner <martin@tuio.org>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioObject3D.h
+++ b/TUIO/TuioObject3D.h
@@ -1,0 +1,319 @@
+/*
+ TUIO C++ Library
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+*/
+
+#ifndef INCLUDED_TUIOOBJECT3D_H
+#define INCLUDED_TUIOOBJECT3D_H
+
+#include "TuioContainer.h"
+
+namespace TUIO {
+
+	/**
+	 * The TuioObject3D class encapsulates /tuio/3Dobj TUIO objects.
+	 *
+	 * @author Nicolas Bremard
+	 * @version 1.1.7
+	 */
+	class LIBDECL TuioObject3D : public TuioContainer {
+
+	protected:
+		/**
+		 * The individual symbol ID number that is assigned to each TuioObject.
+		 */
+		int symbol_id;
+		/**
+		 * The roll angle value.
+		 */
+		float roll;
+		/**
+		 * The roll speed value.
+		 */
+		float roll_speed;
+		/**
+		 * The roll acceleration value.
+		 */
+		float roll_accel;
+		/**
+		 * The pitch angle value.
+		 */
+		float pitch;
+		/**
+		 * The pitch speed value.
+		 */
+		float pitch_speed;
+		/**
+		 * The pitch acceleration value.
+		 */
+		float pitch_accel;
+		/**
+		 * The yaw angle value.
+		 */
+		float yaw;
+		/**
+		 * The yaw speed value.
+		 */
+		float yaw_speed;
+		/**
+		 * The yaw acceleration value.
+		 */
+		float yaw_accel;
+
+		/**
+		 * The rotation acceleration value.
+		 */
+		float rotation_accel;
+
+		float rollThreshold,pitchThreshold,yawThreshold;
+		OneEuroFilter *rollFilter, *pitchFilter, *yawFilter;
+
+	public:
+		using TuioContainer::update;
+
+		/**
+		 * This constructor takes a TuioTime argument and assigns it along with the provided
+		 * Session ID, Symbol ID, X and Y coordinate and angle to the newly created TuioObject.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	si	the Session ID  to assign
+		 * @param	sym	the Symbol ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 */
+		TuioObject3D(TuioTime ttime, long si, int sym, float xp, float yp, float zp, float ro, float po, float yo);
+
+		/**
+		 * This constructor takes the provided Session ID, Symbol ID, X and Y coordinate
+		 * and angle, and assigs these values to the newly created TuioObject.
+		 *
+		 * @param	si	the Session ID  to assign
+		 * @param	sym	the Symbol ID  to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 */
+		TuioObject3D(long si, int sym, float xp, float yp, float zp, float ro, float po, float yo);
+
+		/**
+		 * This constructor takes the atttibutes of the provided TuioObject
+		 * and assigs these values to the newly created TuioObject.
+		 *
+		 * @param	tobj	the TuioObject to assign
+		 */
+		TuioObject3D(TuioObject3D *tobj);
+
+		/**
+		 * The destructor is doing nothing in particular.
+		 */
+		virtual ~TuioObject3D() {
+			if (rollFilter) delete rollFilter;
+			if (pitchFilter) delete pitchFilter;
+			if (yawFilter) delete yawFilter;
+		};
+
+		/**
+		 * Takes a TuioTime argument and assigns it along with the provided
+		 * X and Y coordinate, angle, X and Y velocity, motion acceleration,
+		 * rotation speed and rotation acceleration to the private TuioObject attributes.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 * @param	xs	the X velocity to assign
+		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
+		 * @param	ros	the roll orientation speed to assign
+		 * @param	pos	the pitch orientation speed to assign
+		 * @param	yos	the yaw orientation speed to assign
+		 * @param	ma	the motion acceleration to assign
+		 * @param	ra	the rotation acceleration to assign
+		 */
+		void update(TuioTime ttime, float xp, float yp, float zp, float ro, float po, float yo, float xs, float ys, float zs, float ros, float pos, float yos, float ma, float ra);
+
+		/**
+		 * Assigns the provided X and Y coordinate, angle, X and Y velocity, motion acceleration
+		 * rotation velocity and rotation acceleration to the private TuioContainer attributes.
+		 * The TuioTime time stamp remains unchanged.
+		 *
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 * @param	xs	the X velocity to assign
+		 * @param	ys	the Y velocity to assign
+		 * @param	zs	the Z velocity to assign
+		 * @param	ros	the roll orientation speed to assign
+		 * @param	pos	the pitch orientation speed to assign
+		 * @param	yos	the yaw orientation speed to assign
+		 * @param	ma	the motion acceleration to assign
+		 * @param	ra	the rotation acceleration to assign
+		 */
+		void update(float xp, float yp, float zp, float ro, float po, float yo, float xs, float ys, float zs, float ros, float pos, float yos, float ma, float ra);
+
+		/**
+		 * Takes a TuioTime argument and assigns it along with the provided
+		 * X and Y coordinate and angle to the private TuioObject attributes.
+		 * The speed and accleration values are calculated accordingly.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
+		 * @param	ro	the roll orientation to assign
+		 * @param	po	the pitch orientation to assign
+		 * @param	yo	the yaw orientation to assign
+		 */
+		void update(TuioTime ttime, float xp, float yp, float zp, float ro, float po, float yo);
+
+		/**
+		 * This method is used to calculate the speed and acceleration values of a
+		 * TuioObject with unchanged position and angle.
+		 */
+		void stop(TuioTime ttime);
+
+		/**
+		 * Takes the atttibutes of the provided TuioObject
+		 * and assigs these values to this TuioObject.
+		 * The TuioTime time stamp of this TuioContainer remains unchanged.
+		 *
+		 * @param	tobj	the TuioContainer to assign
+		 */
+		void update(TuioObject3D *tobj);
+
+		/**
+		 * Returns the symbol ID of this TuioObject.
+		 * @return	the symbol ID of this TuioObject
+		 */
+		int getSymbolID() const;
+
+
+		/**
+		 * Returns the roll angle of this TuioObject.
+		 * @return	the roll angle of this TuioObject
+		 */
+		float getRoll() const;
+
+		/**
+		 * Returns the roll angle in degrees of this TuioObject.
+		 * @return	the roll angle in degrees of this TuioObject
+		 */
+		float getRollDegrees() const;
+
+		/**
+		 * Returns the roll speed of this TuioObject.
+		 * @return	the roll speed of this TuioObject
+		 */
+		float getRollSpeed() const;
+
+		/**
+		 * Returns the roll accel of this TuioObject.
+		 * @return	the roll accel of this TuioObject
+		 */
+		float getRollAccel() const;
+
+		/**
+		 * Returns the pitch angle of this TuioObject.
+		 * @return	the pitch angle of this TuioObject
+		 */
+		float getPitch() const;
+
+		/**
+		 * Returns the pitch angle in degrees of this TuioObject.
+		 * @return	the pitch angle in degrees of this TuioObject
+		 */
+		float getPitchDegrees() const;
+
+		/**
+		 * Returns the pitch speed of this TuioObject.
+		 * @return	the pitch speed of this TuioObject
+		 */
+		float getPitchSpeed() const;
+		
+		/**
+		 * Returns the pitch accel of this TuioObject.
+		 * @return	the pitch accel of this TuioObject
+		 */
+		float getPitchAccel() const;
+
+		/**
+		 * Returns the yaw angle of this TuioObject.
+		 * @return	the yaw angle of this TuioObject
+		 */
+		float getYaw() const;
+
+		/**
+		 * Returns the yaw angle in degrees of this TuioObject.
+		 * @return	the yaw angle in degrees of this TuioObject
+		 */
+		float getYawDegrees() const;
+
+		/**
+		 * Returns the yaw speed of this TuioObject.
+		 * @return	the yaw speed of this TuioObject
+		 */
+		float getYawSpeed() const;
+
+		/**
+		 * Returns the yaw accel of this TuioObject.
+		 * @return	the yaw accel of this TuioObject
+		 */
+		float getYawAccel() const;
+
+
+		/**
+		 * Returns the rotation acceleration of this TuioObject.
+		 * @return	the rotation acceleration of this TuioObject
+		 */
+		float getRotationAccel() const;
+
+		/**
+		 * Returns true of this TuioObject is moving.
+		 * @return	true of this TuioObject is moving
+		 */
+		bool isMoving() const;
+
+		void addRollThreshold(float thresh);
+		void addPitchThreshold(float thresh);
+		void addYawThreshold(float thresh);
+
+		void removeRollThreshold();
+		void removePitchThreshold();
+		void removeYawThreshold();
+
+		void addRollFilter(float mcut, float beta);
+		void addPitchFilter(float mcut, float beta);
+		void addYawFilter(float mcut, float beta);
+
+		void removeRollFilter();
+		void removePitchFilter();
+		void removeYawFilter();
+	};
+}
+#endif

--- a/TUIO/TuioPoint.cpp
+++ b/TUIO/TuioPoint.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioPoint.cpp
+++ b/TUIO/TuioPoint.cpp
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -20,26 +20,30 @@
 
 using namespace TUIO;
 
-TuioPoint::TuioPoint (float xp, float yp) {
+TuioPoint::TuioPoint (float xp, float yp, float zp) {
 	xpos = xp;
 	ypos = yp;
+	zpos = zp;
 	currentTime = TuioTime::getSessionTime();
 	startTime = currentTime;
 
 	xposFilter = NULL;
 	yposFilter = NULL;
+	zposFilter = NULL;
 	
 	posThreshold = 0.0f;
 }
 
-TuioPoint::TuioPoint (TuioTime ttime, float xp, float yp) {
+TuioPoint::TuioPoint (TuioTime ttime, float xp, float yp, float zp) {
 	xpos = xp;
 	ypos = yp;
+	zpos = zp;
 	currentTime = ttime;
 	startTime = currentTime;
 
 	xposFilter = NULL;
 	yposFilter = NULL;
+	zposFilter = NULL;
 	
 	posThreshold = 0.0f;
 }
@@ -47,11 +51,13 @@ TuioPoint::TuioPoint (TuioTime ttime, float xp, float yp) {
 TuioPoint::TuioPoint (TuioPoint *tpoint) {
 	xpos = tpoint->getX();
 	ypos = tpoint->getY();
+	zpos = tpoint->getZ();
 	currentTime = TuioTime::getSessionTime();
 	startTime = currentTime;
 
 	xposFilter = NULL;
 	yposFilter = NULL;
+	zposFilter = NULL;
 	
 	posThreshold = 0.0f;
 }
@@ -59,30 +65,43 @@ TuioPoint::TuioPoint (TuioPoint *tpoint) {
 void TuioPoint::update (TuioPoint *tpoint) {
 	xpos = tpoint->getX();
 	ypos = tpoint->getY();
+	zpos = tpoint->getZ();
 }
 
-void TuioPoint::update (float xp, float yp) {
+void TuioPoint::update (float xp, float yp, float zp) {
 	xpos = xp;
 	ypos = yp;
+	zpos = zp;
 }
 
-void TuioPoint::update (TuioTime ttime, float xp, float yp) {
+void TuioPoint::update (TuioTime ttime, float xp, float yp, float zp) {
 	
-	if (xposFilter && yposFilter) {
+	if (xposFilter && yposFilter && zposFilter) {
 		TuioTime diffTime = ttime - currentTime;
 		float dt = diffTime.getTotalMilliseconds()/1000.0f;
 		xp = xposFilter->filter(xp,dt);
 		yp = yposFilter->filter(yp,dt);
+		zp = yposFilter->filter(zp, dt);
 	}
 		
 	float dx = fabs(xpos - xp);
 	float dy = fabs(ypos - yp);
-	if ((dx>posThreshold) || (dy>posThreshold)) {
+	float dz = fabs(zpos - zp);
+	if ((dx>posThreshold) || (dy>posThreshold) || (dz > posThreshold)) {
 		xpos = xp;
 		ypos = yp;
+		zpos = zp;
 	}
 
 	currentTime = ttime;
+}
+
+void TuioPoint::update(float xp, float yp) {
+	update(xp, yp, 0);
+}
+
+void TuioPoint::update(TuioTime ttime, float xp, float yp) {
+	update(ttime, xp, yp, 0);
 }
 
 
@@ -94,52 +113,127 @@ float TuioPoint::getY() const{
 	return ypos;
 }
 
-float TuioPoint::getDistance(float xp, float yp) const{
-	float dx = xpos-xp;
-	float dy = ypos-yp;
-	return sqrtf(dx*dx+dy*dy);
+float TuioPoint::getZ() const {
+	return zpos;
 }
 
-float TuioPoint::getScreenDistance(float xp, float yp, int w, int h) const{
+float TuioPoint::getDistance(float xp, float yp, float zp) const{
+	float dx = xpos-xp;
+	float dy = ypos - yp;
+	float dz = zpos - zp;
+	return sqrtf(dx*dx+dy*dy+dz*dz);
+}
+
+float TuioPoint::getDistance(float xp, float yp) const {
+	float dx = xpos - xp;
+	float dy = ypos - yp;
+	return sqrtf(dx*dx + dy * dy);
+}
+
+float TuioPoint::getSpaceDistance(float xp, float yp, float zp, int w, int h, int d) const{
 	float dx = w*xpos-w*xp;
 	float dy = h*ypos-h*yp;
-	return sqrtf(dx*dx+dy*dy);
+	float dz = d * zpos - d * zp;
+	return sqrtf(dx*dx+dy*dy+dz*dz);
 }
 
 float TuioPoint::getDistance(TuioPoint *tpoint) const{
-	return getDistance(tpoint->getX(),tpoint->getY());
+	return getDistance(tpoint->getX(),tpoint->getY(), tpoint->getZ());
 }
 
 
-float TuioPoint::getAngle(float xp, float yp) const{
-	float side = xpos-xp;
-	float height = ypos-yp;
-	float distance = getDistance(xp,yp);
+float TuioPoint::getAngle(float xp, float yp) const {
+	float side = xpos - xp;
+	float height = ypos - yp;
+	float distance = getDistance(xp, yp);
 
-	float angle = (float)(asin(side/distance)+M_PI/2);
-	if (height<0) angle = 2.0f*(float)M_PI-angle;
+	float angle = (float)(asin(side / distance) + M_PI / 2);
+	if (height < 0) angle = 2.0f*(float)M_PI - angle;
 
 	return angle;
+
 }
 
-float TuioPoint::getAngle(TuioPoint *tpoint) const{
+float TuioPoint::getAngle(TuioPoint *tpoint) const {
+	return getAngle(tpoint->getX(), tpoint->getY());
+}
+
+float TuioPoint::getAngleDegrees(float xp, float yp) const {
+	return ((getAngle(xp, yp) / (float)M_PI)*180.0f);
+}
+
+float TuioPoint::getAngleDegrees(TuioPoint *tpoint) const {
+	return ((getAngle(tpoint) / (float)M_PI)*180.0f);
+}
+
+
+
+float TuioPoint::getRollAngle(float xp, float yp, float zp) const{
+
+	return getAngle(xp,yp);
+}
+
+float TuioPoint::getRollAngle(TuioPoint *tpoint) const{
 	return getAngle(tpoint->getX(),tpoint->getY());
 }
 
-float TuioPoint::getAngleDegrees(float xp, float yp) const{
+float TuioPoint::getRollAngleDegrees(float xp, float yp, float zp) const{
 	return ((getAngle(xp,yp)/(float)M_PI)*180.0f);
 }
 
-float TuioPoint::getAngleDegrees(TuioPoint *tpoint) const{
-	return ((getAngle(tpoint)/(float)M_PI)*180.0f);
+float TuioPoint::getRollAngleDegrees(TuioPoint *tpoint) const{
+	return ((getRollAngle(tpoint)/(float)M_PI)*180.0f);
 }
 
-int TuioPoint::getScreenX(int width) const{
+
+
+
+
+float TuioPoint::getPitchAngle(float xp, float yp, float zp) const {
+
+	return getAngle(zp, yp);
+}
+
+float TuioPoint::getPitchAngle(TuioPoint *tpoint) const {
+	return getAngle(tpoint->getZ(), tpoint->getY());
+}
+
+float TuioPoint::getPitchAngleDegrees(float xp, float yp, float zp) const {
+	return ((getAngle(zp, yp) / (float)M_PI)*180.0f);
+}
+
+float TuioPoint::getPitchAngleDegrees(TuioPoint *tpoint) const {
+	return ((getPitchAngle(tpoint) / (float)M_PI)*180.0f);
+}
+
+float TuioPoint::getYawAngle(float xp, float yp, float zp) const {
+
+	return getAngle(xp, zp);
+}
+
+float TuioPoint::getYawAngle(TuioPoint *tpoint) const {
+	return getAngle(tpoint->getX(), tpoint->getZ());
+}
+
+float TuioPoint::getYawAngleDegrees(float xp, float yp, float zp) const {
+	return ((getAngle(xp, zp) / (float)M_PI)*180.0f);
+}
+
+float TuioPoint::getYawAngleDegrees(TuioPoint *tpoint) const {
+	return ((getYawAngle(tpoint) / (float)M_PI)*180.0f);
+}
+
+
+int TuioPoint::getSpaceX(int width) const{
 	return (int)floor(xpos*width+0.5f);
 }
 
-int TuioPoint::getScreenY(int height) const{
+int TuioPoint::getSpaceY(int height) const{
 	return (int)floor(ypos*height+0.5f);
+}
+
+int TuioPoint::getSpaceZ(int depth) const {
+	return (int)floor(zpos*depth + 0.5f);
 }
 
 TuioTime TuioPoint::getTuioTime() const{
@@ -172,4 +266,6 @@ void TuioPoint::removePositionFilter() {
 	xposFilter = NULL;
 	if (yposFilter) delete yposFilter;
 	yposFilter = NULL;
+	if (zposFilter) delete zposFilter;
+	zposFilter = NULL;
 }

--- a/TUIO/TuioPoint.h
+++ b/TUIO/TuioPoint.h
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -28,10 +28,10 @@ namespace TUIO {
 
 	/**
 	 * The TuioPoint class on the one hand is a simple container and utility class to handle TUIO positions in general, 
-	 * on the other hand the TuioPoint is the base class for the TuioCursor and TuioObject classes.
+	 * on the other hand the TuioPoint is the base class for the TuioCursor, TuioObject and TuioBlob classes.
 	 *
-	 * @author Martin Kaltenbrunner
-	 * @version 1.1.6
+	 * @author Nicolas Bremard
+	 * @version 1.1.7
 	 */ 
 	class LIBDECL TuioPoint {
 
@@ -41,9 +41,13 @@ namespace TUIO {
 		 */
 		float xpos;
 		/**
-		 * X coordinate, representated as a floating point value in a range of 0..1  
+		 * Y coordinate, representated as a floating point value in a range of 0..1  
 		 */
 		float ypos;
+		/**
+		 * Z coordinate, representated as a floating point value in a range of 0..1
+		 */
+		float zpos;
 		/**
 		 * The time stamp of the last update represented as TuioTime (time since session start)
 		 */
@@ -55,6 +59,7 @@ namespace TUIO {
 
 		OneEuroFilter *xposFilter;
 		OneEuroFilter *yposFilter;
+		OneEuroFilter *zposFilter;
 		float posThreshold;
 
 	public:
@@ -62,7 +67,7 @@ namespace TUIO {
 		 * The default constructor takes no arguments and sets
 		 * its coordinate attributes to zero and its time stamp to the current session time.
 		 */
-		TuioPoint (float xp, float yp);
+		TuioPoint (float xp, float yp, float zp);
 
 		/**
 		 * This constructor takes a TuioTime object and two floating point coordinate arguments and sets
@@ -71,8 +76,9 @@ namespace TUIO {
 		 * @param	ttime	the TuioTime to assign
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 */
-		TuioPoint (TuioTime ttime, float xp, float yp);
+		TuioPoint (TuioTime ttime, float xp, float yp, float zp);
 
 		/**
 		 * This constructor takes a TuioPoint argument and sets its coordinate attributes
@@ -88,6 +94,7 @@ namespace TUIO {
 		virtual ~TuioPoint(){
 			if (xposFilter) delete xposFilter;
 			if (yposFilter) delete yposFilter;
+			if (zposFilter) delete zposFilter;
 		};
 
 		/**
@@ -104,8 +111,9 @@ namespace TUIO {
 		 *
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 */
-		void update (float xp, float yp);
+		void update (float xp, float yp, float zp);
 
 		/**
 		 * Takes a TuioTime object and two floating point coordinate arguments and updates its coordinate attributes 
@@ -114,8 +122,29 @@ namespace TUIO {
 		 * @param	ttime	the TuioTime to assign
 		 * @param	xp	the X coordinate to assign
 		 * @param	yp	the Y coordinate to assign
+		 * @param	zp	the Z coordinate to assign
 		 */
-		void update (TuioTime ttime, float xp, float yp);
+		void update (TuioTime ttime, float xp, float yp, float zp);
+
+
+		/**
+		 * Takes two floating point coordinate arguments and updates its coordinate attributes
+		 * to the coordinates of the provided TuioPoint and leaves its time stamp unchanged.
+		 *
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 */
+		void update(float xp, float yp);
+
+		/**
+		 * Takes a TuioTime object and two floating point coordinate arguments and updates its coordinate attributes
+		 * to the coordinates of the provided TuioPoint and its time stamp to the provided TUIO time object.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	xp	the X coordinate to assign
+		 * @param	yp	the Y coordinate to assign
+		 */
+		void update(TuioTime ttime, float xp, float yp);
 
 		
 		/**
@@ -129,9 +158,26 @@ namespace TUIO {
 		 * @return	the Y coordinate of this TuioPoint
 		 */
 		float getY() const;
+
+		/**
+		 * Returns the Z coordinate of this TuioPoint.
+		 * @return	the Z coordinate of this TuioPoint
+		 */
+		float getZ() const;
 		
 		/**
 		 * Returns the distance to the provided coordinates 
+		 *
+		 * @param	xp	the X coordinate of the distant point
+		 * @param	yp	the Y coordinate of the distant point
+		 * @param	zp	the Y coordinate of the distant point
+		 * @return	the distance to the provided coordinates
+		 */
+		float getDistance(float xp, float yp, float zp) const;
+
+
+		/**
+		 * Returns the distance to the provided coordinates
 		 *
 		 * @param	xp	the X coordinate of the distant point
 		 * @param	yp	the Y coordinate of the distant point
@@ -139,14 +185,20 @@ namespace TUIO {
 		 */
 		float getDistance(float xp, float yp) const;
 
+
 		/**
-		 * Returns the distance to the provided coordinates 
+		 * Returns the distance to the provided coordinates
 		 *
 		 * @param	xp	the X coordinate of the distant point
 		 * @param	yp	the Y coordinate of the distant point
+		 * @param	zp	the Y coordinate of the distant point
+		 * @param	w	the width of the space
+		 * @param	h	the height of the space
+		 * @param	d	the depth of the space
 		 * @return	the distance to the provided coordinates
 		 */
-		float getScreenDistance(float xp, float yp, int w, int h) const;
+		float getSpaceDistance(float xp, float yp, float zp, int w, int h, int d) const;
+
 		/**
 		 * Returns the distance to the provided TuioPoint 
 		 *
@@ -154,50 +206,182 @@ namespace TUIO {
 		 * @return	the distance to the provided TuioPoint
 		 */
 		float getDistance(TuioPoint *tpoint) const;
+
+
 		/**
-		 * Returns the angle to the provided coordinates 
+		 * Returns the 2D angle  to the provided coordinates
 		 *
 		 * @param	xp	the X coordinate of the distant point
 		 * @param	yp	the Y coordinate of the distant point
-		 * @return	the angle to the provided coordinates
+		 * @return	the 2D angle to the provided coordinates
 		 */
 		float getAngle(float xp, float yp) const;
 		/**
-		 * Returns the angle to the provided TuioPoint 
+		 * Returns the 2D angle to the provided TuioPoint
 		 *
 		 * @param	tpoint	the distant TuioPoint
-		 * @return	the angle to the provided TuioPoint
+		 * @return	the 2D angle to the provided TuioPoint
 		 */
 		float getAngle(TuioPoint *tpoint) const;
 		/**
-		 * Returns the angle in degrees to the provided coordinates 
+		 * Returns the 2D angle in degrees to the provided coordinates
 		 *
 		 * @param	xp	the X coordinate of the distant point
 		 * @param	yp	the Y coordinate of the distant point
-		 * @return	the angle in degrees to the provided TuioPoint
+		 * @param	zp	the Z coordinate of the distant point
+		 * @return	the 2D angle in degrees to the provided TuioPoint
 		 */
 		float getAngleDegrees(float xp, float yp) const;
 		/**
-		 * Returns the angle in degrees to the provided TuioPoint 
+		 * Returns the 2D angle in degrees to the provided TuioPoint
 		 *
 		 * @param	tpoint	the distant TuioPoint
-		 * @return	the angle in degrees to the provided TuioPoint
+		 * @return	the 2D angle in degrees to the provided TuioPoint
 		 */
 		float getAngleDegrees(TuioPoint *tpoint) const;
+
 		/**
-		 * Returns the X coordinate in pixels relative to the provided screen width. 
+		 * Returns the roll angle  to the provided coordinates
 		 *
-		 * @param	width	the screen width
-		 * @return	the X coordinate of this TuioPoint in pixels relative to the provided screen width
+		 * @param	xp	the X coordinate of the distant point
+		 * @param	yp	the Y coordinate of the distant point
+		 * @param	zp	the Z coordinate of the distant point
+		 * @return	the roll angle to the provided coordinates
 		 */
-		int getScreenX(int width) const;
+		float getRollAngle(float xp, float yp, float zp) const;
+		/**
+		 * Returns the roll angle to the provided TuioPoint
+		 *
+		 * @param	tpoint	the distant TuioPoint
+		 * @return	the roll angle to the provided TuioPoint
+		 */
+		float getRollAngle(TuioPoint *tpoint) const;
+		/**
+		 * Returns the roll angle in degrees to the provided coordinates
+		 *
+		 * @param	xp	the X coordinate of the distant point
+		 * @param	yp	the Y coordinate of the distant point
+		 * @param	zp	the Z coordinate of the distant point
+		 * @return	the roll angle in degrees to the provided TuioPoint
+		 */
+		float getRollAngleDegrees(float xp, float yp, float zp) const;
+		/**
+		 * Returns the roll angle in degrees to the provided TuioPoint
+		 *
+		 * @param	tpoint	the distant TuioPoint
+		 * @return	the roll angle in degrees to the provided TuioPoint
+		 */
+		float getRollAngleDegrees(TuioPoint *tpoint) const;
+
+
+		/**
+		 * Returns the pitch angle  to the provided coordinates
+		 *
+		 * @param	xp	the X coordinate of the distant point
+		 * @param	yp	the Y coordinate of the distant point
+		 * @param	zp	the Z coordinate of the distant point
+		 * @return	the pitch angle to the provided coordinates
+		 */
+		float getPitchAngle(float xp, float yp, float zp) const;
+		/**
+		 * Returns the pitch angle to the provided TuioPoint
+		 *
+		 * @param	tpoint	the distant TuioPoint
+		 * @return	the pitch angle to the provided TuioPoint
+		 */
+		float getPitchAngle(TuioPoint *tpoint) const;
+		/**
+		 * Returns the pitch angle in degrees to the provided coordinates
+		 *
+		 * @param	xp	the X coordinate of the distant point
+		 * @param	yp	the Y coordinate of the distant point
+		 * @param	zp	the Z coordinate of the distant point
+		 * @return	the pitch angle in degrees to the provided TuioPoint
+		 */
+		float getPitchAngleDegrees(float xp, float yp, float zp) const;
+		/**
+		 * Returns the pitch angle in degrees to the provided TuioPoint
+		 *
+		 * @param	tpoint	the distant TuioPoint
+		 * @return	the pitch angle in degrees to the provided TuioPoint
+		 */
+		float getPitchAngleDegrees(TuioPoint *tpoint) const;
+
+		/**
+		 * Returns the yaw angle  to the provided coordinates 
+		 *
+		 * @param	xp	the X coordinate of the distant point
+		 * @param	yp	the Y coordinate of the distant point
+		 * @param	zp	the Z coordinate of the distant point
+		 * @return	the yaw angle to the provided coordinates
+		 */
+		float getYawAngle(float xp, float yp, float zp) const;
+		/**
+		 * Returns the yaw angle to the provided TuioPoint 
+		 *
+		 * @param	tpoint	the distant TuioPoint
+		 * @return	the yaw angle to the provided TuioPoint
+		 */
+		float getYawAngle(TuioPoint *tpoint) const;
+		/**
+		 * Returns the yaw angle in degrees to the provided coordinates 
+		 *
+		 * @param	xp	the X coordinate of the distant point
+		 * @param	yp	the Y coordinate of the distant point
+		 * @param	zp	the Z coordinate of the distant point
+		 * @return	the yaw angle in degrees to the provided TuioPoint
+		 */
+		float getYawAngleDegrees(float xp, float yp, float zp) const;
+		/**
+		 * Returns the yaw angle in degrees to the provided TuioPoint 
+		 *
+		 * @param	tpoint	the distant TuioPoint
+		 * @return	the yaw angle in degrees to the provided TuioPoint
+		 */
+		float getYawAngleDegrees(TuioPoint *tpoint) const;
+
+
+		/**
+		 * Returns the X coordinate in units relative to the provided space width. 
+		 *
+		 * @param	width	the space width
+		 * @return	the X coordinate of this TuioPoint in units relative to the provided space width
+		 */
+		int getSpaceX(int width) const;
 		/*
-		 * Returns the Y coordinate in pixels relative to the provided screen height. 
+		 * Returns the Y coordinate in units relative to the provided space height. 
 		 *
-		 * @param	height	the screen height
-		 * @return	the Y coordinate of this TuioPoint in pixels relative to the provided screen height
+		 * @param	height	the space height
+		 * @return	the Y coordinate of this TuioPoint in units relative to the provided space height
 		 */
-		int getScreenY(int height) const;
+		int getSpaceY(int height) const;		
+		/*
+		 * Returns the Z coordinate in pixels relative to the provided space depth.
+		 *
+		 * @param	depth	the space depth
+		 * @return	the Z coordinate of this TuioPoint in units relative to the provided space depth
+		 */
+		int getSpaceZ(int depth) const;
+
+
+		/**
+		 * Returns the X coordinate in unit relative to the provided screen width. (Kept for retro compatibility)
+		 *
+		 * @param	width	the space width
+		 * @return	the X coordinate of this TuioPoint in units relative to the provided screen width
+		 */
+		int getScreenX(int width) const { return getSpaceX(width); }
+		/*
+		 * Returns the Y coordinate in units relative to the provided screen height. (Kept for retro compatibility)
+		 *
+		 * @param	height	the space height
+		 * @return	the Y coordinate of this TuioPoint in units relative to the provided screen height
+		 */
+		int getScreenY(int height) const { return getSpaceY(height); }
+
+
+
+
 		/**
 		 * Returns current time stamp of this TuioPoint as TuioTime 
 		 *

--- a/TUIO/TuioPoint.h
+++ b/TUIO/TuioPoint.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -27,12 +28,12 @@
 namespace TUIO {
 
 	/**
-	 * The TuioPoint class on the one hand is a simple container and utility class to handle TUIO positions in general, 
-	 * on the other hand the TuioPoint is the base class for the TuioCursor, TuioObject and TuioBlob classes.
+	 * The TuioPoint class on the one hand is a simple container and utility class to handle TUIO positions in general,
+	 * on the other hand the TuioPoint is the base class for the TuioCursor and TuioObject classes.
 	 *
-	 * @author Nicolas Bremard
+	 * @author Martin Kaltenbrunner
 	 * @version 1.1.7
-	 */ 
+	 */
 	class LIBDECL TuioPoint {
 
 	protected:

--- a/TUIO/TuioServer.cpp
+++ b/TUIO/TuioServer.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/TUIO/TuioServer.cpp
+++ b/TUIO/TuioServer.cpp
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -24,10 +24,16 @@ using namespace osc;
 
 TuioServer::TuioServer() 
 	:full_update			(false)
-	,periodic_update		(false)	
-	,objectProfileEnabled	(true)
-	,cursorProfileEnabled	(true)
-	,blobProfileEnabled		(true)
+	,periodic_update		(false)
+	, objectProfileEnabled(true)
+	, cursorProfileEnabled(true)
+	, blobProfileEnabled(true)
+	, object25DProfileEnabled(true)
+	, cursor25DProfileEnabled(true)
+	, blob25DProfileEnabled(true)
+	, object3DProfileEnabled(true)
+	, cursor3DProfileEnabled(true)
+	, blob3DProfileEnabled(true)
 	,source_name			(NULL)
 {
 	OscSender *oscsend = new UdpSender();
@@ -40,6 +46,12 @@ TuioServer::TuioServer(const char *host, int port)
 ,objectProfileEnabled	(true)
 ,cursorProfileEnabled	(true)
 ,blobProfileEnabled		(true)
+, object25DProfileEnabled(true)
+, cursor25DProfileEnabled(true)
+, blob25DProfileEnabled(true)
+, object3DProfileEnabled(true)
+, cursor3DProfileEnabled(true)
+, blob3DProfileEnabled(true)
 ,source_name			(NULL)
 {
 	OscSender *oscsend = new UdpSender(host,port);
@@ -52,6 +64,12 @@ TuioServer::TuioServer(OscSender *oscsend)
 	,objectProfileEnabled	(true)
 	,cursorProfileEnabled	(true)
 	,blobProfileEnabled		(true)
+	, object25DProfileEnabled(true)
+	, cursor25DProfileEnabled(true)
+	, blob25DProfileEnabled(true)
+	, object3DProfileEnabled(true)
+	, cursor3DProfileEnabled(true)
+	, blob3DProfileEnabled(true)
 	,source_name			(NULL)
 {
 	initialize(oscsend);
@@ -69,11 +87,27 @@ void TuioServer::initialize(OscSender *oscsend) {
 	objectUpdateTime = TuioTime(currentFrameTime);
 	cursorUpdateTime = TuioTime(currentFrameTime);
 	blobUpdateTime = TuioTime(currentFrameTime);
+
+	object25DUpdateTime = TuioTime(currentFrameTime);
+	cursor25DUpdateTime = TuioTime(currentFrameTime);
+	blob25DUpdateTime = TuioTime(currentFrameTime);
+
+	object3DUpdateTime = TuioTime(currentFrameTime);
+	cursor3DUpdateTime = TuioTime(currentFrameTime);
+	blob3DUpdateTime = TuioTime(currentFrameTime);
 	
 	if (cursorProfileEnabled) sendEmptyCursorBundle();
 	if (objectProfileEnabled) sendEmptyObjectBundle();
 	if (blobProfileEnabled) sendEmptyBlobBundle();
-	
+
+	if (cursor25DProfileEnabled) sendEmptyCursor25DBundle();
+	if (object25DProfileEnabled) sendEmptyObject25DBundle();
+	if (blob25DProfileEnabled) sendEmptyBlob25DBundle();
+
+	if (cursor3DProfileEnabled) sendEmptyCursor3DBundle();
+	if (object3DProfileEnabled) sendEmptyObject3DBundle();
+	if (blob3DProfileEnabled) sendEmptyBlob3DBundle();
+
 	invert_x = false;
 	invert_y = false;
 	invert_a = false;	
@@ -85,15 +119,33 @@ TuioServer::~TuioServer() {
 	stopUntouchedMovingCursors();
 	stopUntouchedMovingObjects();
 	stopUntouchedMovingBlobs();
+	stopUntouchedMovingCursors25D();
+	stopUntouchedMovingObjects25D();
+	stopUntouchedMovingBlobs25D();
+	stopUntouchedMovingCursors3D();
+	stopUntouchedMovingObjects3D();
+	stopUntouchedMovingBlobs3D();
 	
 	initFrame(TuioTime::getSessionTime());
 	removeUntouchedStoppedCursors();
 	removeUntouchedStoppedObjects();
 	removeUntouchedStoppedBlobs();
+	removeUntouchedStoppedCursors25D();
+	removeUntouchedStoppedObjects25D();
+	removeUntouchedStoppedBlobs25D();
+	removeUntouchedStoppedCursors3D();
+	removeUntouchedStoppedObjects3D();
+	removeUntouchedStoppedBlobs3D();
 	
 	if (cursorProfileEnabled) sendEmptyCursorBundle();
 	if (objectProfileEnabled) sendEmptyObjectBundle();
 	if (blobProfileEnabled) sendEmptyBlobBundle();
+	if (cursor25DProfileEnabled) sendEmptyCursor25DBundle();
+	if (object25DProfileEnabled) sendEmptyObject25DBundle();
+	if (blob25DProfileEnabled) sendEmptyBlob25DBundle();
+	if (cursor3DProfileEnabled) sendEmptyCursor3DBundle();
+	if (object3DProfileEnabled) sendEmptyObject3DBundle();
+	if (blob3DProfileEnabled) sendEmptyBlob3DBundle();
 	
 	delete []oscBuffer;
 	delete oscPacket;
@@ -284,7 +336,231 @@ void TuioServer::commitFrame() {
 		}
 	}
 	updateBlob = false;
+
+
+	// 25D
+
+	if (updateObject25D) {
+		startObject25DBundle();
+		for (std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin(); tuioObject != object25DList.end(); tuioObject++) {
+
+			// start a new packet if we exceed the packet capacity
+			if ((oscPacket->Capacity() - oscPacket->Size()) < OBJ25D_MESSAGE_SIZE) {
+				sendObject25DBundle(currentFrame);
+				startObject25DBundle();
+			}
+			TuioObject25D *tobj = (*tuioObject);
+			if ((full_update) || (tobj->getTuioTime() == currentFrameTime)) addObject25DMessage(tobj);
+		}
+		object25DUpdateTime = TuioTime(currentFrameTime);
+		sendObject25DBundle(currentFrame);
+	}
+	else if (object25DProfileEnabled && periodic_update) {
+
+		TuioTime timeCheck = currentFrameTime - object25DUpdateTime;
+		if (timeCheck.getSeconds() >= update_interval) {
+			object25DUpdateTime = TuioTime(currentFrameTime);
+			startObject25DBundle();
+			if (full_update) {
+				for (std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin(); tuioObject != object25DList.end(); tuioObject++) {
+					// start a new packet if we exceed the packet capacity
+					if ((oscPacket->Capacity() - oscPacket->Size()) < OBJ25D_MESSAGE_SIZE) {
+						sendObject25DBundle(currentFrame);
+						startObject25DBundle();
+					}
+					addObject25DMessage(*tuioObject);
+				}
+			}
+			sendObject25DBundle(currentFrame);
+		}
+	}
+	updateObject25D = false;
+
+	if (updateCursor25D) {
+		startCursor25DBundle();
+		for (std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin(); tuioCursor != cursor25DList.end(); tuioCursor++) {
+
+			// start a new packet if we exceed the packet capacity
+			if ((oscPacket->Capacity() - oscPacket->Size()) < CUR25D_MESSAGE_SIZE) {
+				sendCursor25DBundle(currentFrame);
+				startCursor25DBundle();
+			}
+			TuioCursor25D *tcur = (*tuioCursor);
+			if ((full_update) || (tcur->getTuioTime() == currentFrameTime)) addCursor25DMessage(tcur);
+		}
+		cursor25DUpdateTime = TuioTime(currentFrameTime);
+		sendCursor25DBundle(currentFrame);
+	}
+	else if (cursor25DProfileEnabled && periodic_update) {
+		TuioTime timeCheck = currentFrameTime - cursor25DUpdateTime;
+		if (timeCheck.getSeconds() >= update_interval) {
+			cursor25DUpdateTime = TuioTime(currentFrameTime);
+			startCursor25DBundle();
+			if (full_update) {
+				for (std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin(); tuioCursor != cursor25DList.end(); tuioCursor++) {
+					// start a new packet if we exceed the packet capacity
+					if ((oscPacket->Capacity() - oscPacket->Size()) < CUR25D_MESSAGE_SIZE) {
+						sendCursor25DBundle(currentFrame);
+						startCursor25DBundle();
+					}
+					addCursor25DMessage(*tuioCursor);
+				}
+			}
+			sendCursor25DBundle(currentFrame);
+		}
+	}
+	updateCursor25D = false;
+
+	if (updateBlob25D) {
+		startBlob25DBundle();
+		for (std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin(); tuioBlob != blob25DList.end(); tuioBlob++) {
+			// start a new packet if we exceed the packet capacity
+			if ((oscPacket->Capacity() - oscPacket->Size()) < BLB25D_MESSAGE_SIZE) {
+				sendBlob25DBundle(currentFrame);
+				startBlob25DBundle();
+			}
+			TuioBlob25D *tblb = (*tuioBlob);
+			if ((full_update) || (tblb->getTuioTime() == currentFrameTime)) addBlob25DMessage(tblb);
+		}
+		blob25DUpdateTime = TuioTime(currentFrameTime);
+		sendBlob25DBundle(currentFrame);
+	}
+	else if (blob25DProfileEnabled && periodic_update) {
+		TuioTime timeCheck = currentFrameTime - blob25DUpdateTime;
+		if (timeCheck.getSeconds() >= update_interval) {
+			blob25DUpdateTime = TuioTime(currentFrameTime);
+			startBlob25DBundle();
+			if (full_update) {
+				for (std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin(); tuioBlob != blob25DList.end(); tuioBlob++) {
+
+					// start a new packet if we exceed the packet capacity
+					if ((oscPacket->Capacity() - oscPacket->Size()) < BLB25D_MESSAGE_SIZE) {
+						sendBlob25DBundle(currentFrame);
+						startBlob25DBundle();
+					}
+					addBlob25DMessage(*tuioBlob);
+				}
+			}
+			sendBlob25DBundle(currentFrame);
+		}
+	}
+	updateBlob25D = false;
+
+
+	// 3D
+
+	if (updateObject3D) {
+		startObject3DBundle();
+		for (std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin(); tuioObject != object3DList.end(); tuioObject++) {
+
+			// start a new packet if we exceed the packet capacity
+			if ((oscPacket->Capacity() - oscPacket->Size()) < OBJ3D_MESSAGE_SIZE) {
+				sendObject3DBundle(currentFrame);
+				startObject3DBundle();
+			}
+			TuioObject3D *tobj = (*tuioObject);
+			if ((full_update) || (tobj->getTuioTime() == currentFrameTime)) addObject3DMessage(tobj);
+		}
+		object3DUpdateTime = TuioTime(currentFrameTime);
+		sendObject3DBundle(currentFrame);
+	}
+	else if (object3DProfileEnabled && periodic_update) {
+
+		TuioTime timeCheck = currentFrameTime - object3DUpdateTime;
+		if (timeCheck.getSeconds() >= update_interval) {
+			object3DUpdateTime = TuioTime(currentFrameTime);
+			startObject3DBundle();
+			if (full_update) {
+				for (std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin(); tuioObject != object3DList.end(); tuioObject++) {
+					// start a new packet if we exceed the packet capacity
+					if ((oscPacket->Capacity() - oscPacket->Size()) < OBJ3D_MESSAGE_SIZE) {
+						sendObject3DBundle(currentFrame);
+						startObject3DBundle();
+					}
+					addObject3DMessage(*tuioObject);
+				}
+			}
+			sendObject3DBundle(currentFrame);
+		}
+	}
+	updateObject3D = false;
+
+	if (updateCursor3D) {
+		startCursor3DBundle();
+		for (std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin(); tuioCursor != cursor3DList.end(); tuioCursor++) {
+
+			// start a new packet if we exceed the packet capacity
+			if ((oscPacket->Capacity() - oscPacket->Size()) < CUR3D_MESSAGE_SIZE) {
+				sendCursor3DBundle(currentFrame);
+				startCursor3DBundle();
+			}
+			TuioCursor3D *tcur = (*tuioCursor);
+			if ((full_update) || (tcur->getTuioTime() == currentFrameTime)) addCursor3DMessage(tcur);
+		}
+		cursor3DUpdateTime = TuioTime(currentFrameTime);
+		sendCursor3DBundle(currentFrame);
+	}
+	else if (cursor3DProfileEnabled && periodic_update) {
+		TuioTime timeCheck = currentFrameTime - cursor3DUpdateTime;
+		if (timeCheck.getSeconds() >= update_interval) {
+			cursor3DUpdateTime = TuioTime(currentFrameTime);
+			startCursor3DBundle();
+			if (full_update) {
+				for (std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin(); tuioCursor != cursor3DList.end(); tuioCursor++) {
+					// start a new packet if we exceed the packet capacity
+					if ((oscPacket->Capacity() - oscPacket->Size()) < CUR3D_MESSAGE_SIZE) {
+						sendCursor3DBundle(currentFrame);
+						startCursor3DBundle();
+					}
+					addCursor3DMessage(*tuioCursor);
+				}
+			}
+			sendCursor3DBundle(currentFrame);
+		}
+	}
+	updateCursor3D = false;
+
+	if (updateBlob3D) {
+		startBlob3DBundle();
+		for (std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin(); tuioBlob != blob3DList.end(); tuioBlob++) {
+			// start a new packet if we exceed the packet capacity
+			if ((oscPacket->Capacity() - oscPacket->Size()) < BLB3D_MESSAGE_SIZE) {
+				sendBlob3DBundle(currentFrame);
+				startBlob3DBundle();
+			}
+			TuioBlob3D *tblb = (*tuioBlob);
+			if ((full_update) || (tblb->getTuioTime() == currentFrameTime)) addBlob3DMessage(tblb);
+		}
+		blob3DUpdateTime = TuioTime(currentFrameTime);
+		sendBlob3DBundle(currentFrame);
+	}
+	else if (blob3DProfileEnabled && periodic_update) {
+		TuioTime timeCheck = currentFrameTime - blob3DUpdateTime;
+		if (timeCheck.getSeconds() >= update_interval) {
+			blob3DUpdateTime = TuioTime(currentFrameTime);
+			startBlob3DBundle();
+			if (full_update) {
+				for (std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin(); tuioBlob != blob3DList.end(); tuioBlob++) {
+
+					// start a new packet if we exceed the packet capacity
+					if ((oscPacket->Capacity() - oscPacket->Size()) < BLB3D_MESSAGE_SIZE) {
+						sendBlob3DBundle(currentFrame);
+						startBlob3DBundle();
+					}
+					addBlob3DMessage(*tuioBlob);
+				}
+			}
+			sendBlob3DBundle(currentFrame);
+		}
+	}
+	updateBlob3D = false;
+
+
 }
+
+
+
+
 
 void TuioServer::sendEmptyCursorBundle() {
 	oscPacket->Clear();	
@@ -391,6 +667,8 @@ void TuioServer::sendObjectBundle(long fseq) {
 }
 
 
+
+
 void TuioServer::sendEmptyBlobBundle() {
 	oscPacket->Clear();	
 	(*oscPacket) << osc::BeginBundleImmediate;
@@ -447,6 +725,400 @@ void TuioServer::sendBlobBundle(long fseq) {
 
 	deliverOscPacket( oscPacket );
 }
+
+
+void TuioServer::sendEmptyCursor25DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/25Dcur") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dcur") << "alive" << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dcur") << "fseq" << -1 << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+void TuioServer::startCursor25DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/25Dcur") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dcur") << "alive";
+	for (std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin(); tuioCursor != cursor25DList.end(); tuioCursor++) {
+		/*if ((*tuioCursor)->getTuioState()!=TUIO_ADDED)*/ (*oscPacket) << (int32)((*tuioCursor)->getSessionID());
+	}
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::addCursor25DMessage(TuioCursor25D *tcur) {
+
+	//if (tcur->getTuioState()==TUIO_ADDED) return;
+
+	float xpos = tcur->getX();
+	float xvel = tcur->getXSpeed();
+	if (invert_x) {
+		xpos = 1 - xpos;
+		xvel = -1 * xvel;
+	}
+	float ypos = tcur->getY();
+	float yvel = tcur->getYSpeed();
+	if (invert_y) {
+		ypos = 1 - ypos;
+		yvel = -1 * yvel;
+	}
+	float zpos = tcur->getZ();
+	float zvel = tcur->getZSpeed();
+	if (invert_z) {
+		zpos = 1 - zpos;
+		zvel = -1 * zvel;
+	}
+
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dcur") << "set";
+	(*oscPacket) << (int32)(tcur->getSessionID()) << xpos << ypos << zpos;
+	(*oscPacket) << xvel << yvel << zvel << tcur->getMotionAccel();
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::sendCursor25DBundle(long fseq) {
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dcur") << "fseq" << (int32)fseq << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+void TuioServer::sendEmptyObject25DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/25Dobj") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dobj") << "alive" << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dobj") << "fseq" << -1 << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+void TuioServer::startObject25DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/25Dobj") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dobj") << "alive";
+	for (std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin(); tuioObject != object25DList.end(); tuioObject++) {
+		(*oscPacket) << (int32)((*tuioObject)->getSessionID());
+	}
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::addObject25DMessage(TuioObject25D *tobj) {
+
+	float xpos = tobj->getX();
+	float xvel = tobj->getXSpeed();
+	if (invert_x) {
+		xpos = 1 - xpos;
+		xvel = -1 * xvel;
+	}
+	float ypos = tobj->getY();
+	float yvel = tobj->getYSpeed();
+	if (invert_y) {
+		ypos = 1 - ypos;
+		yvel = -1 * yvel;
+	}
+	float zpos = tobj->getZ();
+	float zvel = tobj->getZSpeed();
+	if (invert_z) {
+		zpos = 1 - zpos;
+		zvel = -1 * zvel;
+	}
+	float angle = tobj->getAngle();
+	float rvel = tobj->getRotationSpeed();
+	if (invert_a) {
+		angle = 2.0f*(float)M_PI - angle;
+		rvel = -1 * rvel;
+	}
+
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dobj") << "set";
+	(*oscPacket) << (int32)(tobj->getSessionID()) << tobj->getSymbolID() << xpos << ypos << zpos << angle;
+	(*oscPacket) << xvel << yvel << zvel << rvel << tobj->getMotionAccel() << tobj->getRotationAccel();
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::sendObject25DBundle(long fseq) {
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dobj") << "fseq" << (int32)fseq << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+
+
+
+void TuioServer::sendEmptyBlob25DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/25Dblb") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dblb") << "alive" << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dblb") << "fseq" << -1 << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+void TuioServer::startBlob25DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/25Dblb") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dblb") << "alive";
+	for (std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin(); tuioBlob != blob25DList.end(); tuioBlob++) {
+		/*if ((*tuioBlob)->getTuioState()!=TUIO_ADDED)*/ (*oscPacket) << (int32)((*tuioBlob)->getSessionID());
+	}
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::addBlob25DMessage(TuioBlob25D *tblb) {
+
+	//if (tblb->getTuioState()==TUIO_ADDED) return;
+
+	float xpos = tblb->getX();
+	float xvel = tblb->getXSpeed();
+	if (invert_x) {
+		xpos = 1 - xpos;
+		xvel = -1 * xvel;
+	}
+	float ypos = tblb->getY();
+	float yvel = tblb->getYSpeed();
+	if (invert_y) {
+		ypos = 1 - ypos;
+		yvel = -1 * yvel;
+	}
+	float zpos = tblb->getZ();
+	float zvel = tblb->getZSpeed();
+	if (invert_z) {
+		zpos = 1 - zpos;
+		zvel = -1 * zvel;
+	}
+	float angle = tblb->getAngle();
+	float rvel = tblb->getRotationSpeed();
+	if (invert_a) {
+		angle = 2.0f*(float)M_PI - angle;
+		rvel = -1 * rvel;
+	}
+
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dblb") << "set";
+	(*oscPacket) << (int32)(tblb->getSessionID()) << xpos << ypos << zpos << angle << tblb->getWidth() << tblb->getHeight() << tblb->getArea();
+	(*oscPacket) << xvel << yvel << zvel << rvel << tblb->getMotionAccel() << tblb->getRotationAccel();
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::sendBlob25DBundle(long fseq) {
+	(*oscPacket) << osc::BeginMessage("/tuio/25Dblb") << "fseq" << (int32)fseq << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+
+	deliverOscPacket(oscPacket);
+}
+
+
+
+
+void TuioServer::sendEmptyCursor3DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/3Dcur") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dcur") << "alive" << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dcur") << "fseq" << -1 << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+void TuioServer::startCursor3DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/3Dcur") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dcur") << "alive";
+	for (std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin(); tuioCursor != cursor3DList.end(); tuioCursor++) {
+		/*if ((*tuioCursor)->getTuioState()!=TUIO_ADDED)*/ (*oscPacket) << (int32)((*tuioCursor)->getSessionID());
+	}
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::addCursor3DMessage(TuioCursor3D *tcur) {
+
+	//if (tcur->getTuioState()==TUIO_ADDED) return;
+
+	float xpos = tcur->getX();
+	float xvel = tcur->getXSpeed();
+	if (invert_x) {
+		xpos = 1 - xpos;
+		xvel = -1 * xvel;
+	}
+	float ypos = tcur->getY();
+	float yvel = tcur->getYSpeed();
+	if (invert_y) {
+		ypos = 1 - ypos;
+		yvel = -1 * yvel;
+	}
+	float zpos = tcur->getZ();
+	float zvel = tcur->getZSpeed();
+	if (invert_z) {
+		zpos = 1 - zpos;
+		zvel = -1 * zvel;
+	}
+
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dcur") << "set";
+	(*oscPacket) << (int32)(tcur->getSessionID()) << xpos << ypos << zpos;
+	(*oscPacket) << xvel << yvel << zvel << tcur->getMotionAccel();
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::sendCursor3DBundle(long fseq) {
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dcur") << "fseq" << (int32)fseq << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+void TuioServer::sendEmptyObject3DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/3Dobj") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dobj") << "alive" << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dobj") << "fseq" << -1 << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+void TuioServer::startObject3DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/3Dobj") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dobj") << "alive";
+	for (std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin(); tuioObject != object3DList.end(); tuioObject++) {
+		(*oscPacket) << (int32)((*tuioObject)->getSessionID());
+	}
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::addObject3DMessage(TuioObject3D *tobj) {
+
+	float xpos = tobj->getX();
+	float xvel = tobj->getXSpeed();
+	if (invert_x) {
+		xpos = 1 - xpos;
+		xvel = -1 * xvel;
+	}
+	float ypos = tobj->getY();
+	float yvel = tobj->getYSpeed();
+	if (invert_y) {
+		ypos = 1 - ypos;
+		yvel = -1 * yvel;
+	}
+	float zpos = tobj->getZ();
+	float zvel = tobj->getZSpeed();
+	if (invert_z) {
+		zpos = 1 - zpos;
+		zvel = -1 * zvel;
+	}
+	float roll = tobj->getRoll();
+	float rollvel = tobj->getRollSpeed();
+	if (invert_a) {
+		roll = 2.0f*(float)M_PI - roll;
+		rollvel = -1 * rollvel;
+	}
+	float pitch = tobj->getPitch();
+	float pitchvel = tobj->getPitchSpeed();
+	if (invert_b) {
+		pitch = 2.0f*(float)M_PI - pitch;
+		pitchvel = -1 * pitchvel;
+	}
+	float yaw = tobj->getYaw();
+	float yawvel = tobj->getYawSpeed();
+	if (invert_c) {
+		yaw = 2.0f*(float)M_PI - yaw;
+		yawvel = -1 * yawvel;
+	}
+
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dobj") << "set";
+	(*oscPacket) << (int32)(tobj->getSessionID()) << tobj->getSymbolID() << xpos << ypos << zpos << roll << pitch << yaw;
+	(*oscPacket) << xvel << yvel << zvel << rollvel << pitchvel << yawvel << tobj->getMotionAccel() << tobj->getRotationAccel();
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::sendObject3DBundle(long fseq) {
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dobj") << "fseq" << (int32)fseq << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+
+
+
+void TuioServer::sendEmptyBlob3DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/3Dblb") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dblb") << "alive" << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dblb") << "fseq" << -1 << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+	deliverOscPacket(oscPacket);
+}
+
+void TuioServer::startBlob3DBundle() {
+	oscPacket->Clear();
+	(*oscPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*oscPacket) << osc::BeginMessage("/tuio/3Dblb") << "source" << source_name << osc::EndMessage;
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dblb") << "alive";
+	for (std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin(); tuioBlob != blob3DList.end(); tuioBlob++) {
+		/*if ((*tuioBlob)->getTuioState()!=TUIO_ADDED)*/ (*oscPacket) << (int32)((*tuioBlob)->getSessionID());
+	}
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::addBlob3DMessage(TuioBlob3D *tblb) {
+
+	//if (tblb->getTuioState()==TUIO_ADDED) return;
+
+	float xpos = tblb->getX();
+	float xvel = tblb->getXSpeed();
+	if (invert_x) {
+		xpos = 1 - xpos;
+		xvel = -1 * xvel;
+	}
+	float ypos = tblb->getY();
+	float yvel = tblb->getYSpeed();
+	if (invert_y) {
+		ypos = 1 - ypos;
+		yvel = -1 * yvel;
+	}
+	float zpos = tblb->getZ();
+	float zvel = tblb->getZSpeed();
+	if (invert_z) {
+		zpos = 1 - zpos;
+		zvel = -1 * zvel;
+	}
+	float roll = tblb->getRoll();
+	float rollvel = tblb->getRollSpeed();
+	if (invert_a) {
+		roll = 2.0f*(float)M_PI - roll;
+		rollvel = -1 * rollvel;
+	}
+	float pitch = tblb->getPitch();
+	float pitchvel = tblb->getPitchSpeed();
+	if (invert_b) {
+		pitch = 2.0f*(float)M_PI - pitch;
+		pitchvel = -1 * pitchvel;
+	}
+	float yaw = tblb->getYaw();
+	float yawvel = tblb->getYawSpeed();
+	if (invert_c) {
+		yaw = 2.0f*(float)M_PI - yaw;
+		yawvel = -1 * yawvel;
+	}
+
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dblb") << "set";
+	(*oscPacket) << (int32)(tblb->getSessionID()) << xpos << ypos << zpos << roll << pitch << yaw << tblb->getWidth() << tblb->getHeight() << tblb->getDepth() << tblb->getVolume();
+	(*oscPacket) << xvel << yvel << zvel << rollvel << pitchvel << yawvel << tblb->getMotionAccel() << tblb->getRotationAccel();
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::sendBlob3DBundle(long fseq) {
+	(*oscPacket) << osc::BeginMessage("/tuio/3Dblb") << "fseq" << (int32)fseq << osc::EndMessage;
+	(*oscPacket) << osc::EndBundle;
+
+	deliverOscPacket(oscPacket);
+}
+
+
 
 void TuioServer::sendFullMessages() {
 	
@@ -628,6 +1300,445 @@ void TuioServer::sendFullMessages() {
 	(*fullPacket) << osc::BeginMessage( "/tuio/2Dblb") << "fseq" << -1 << osc::EndMessage;
 	(*fullPacket) << osc::EndBundle;
 	deliverOscPacket( fullPacket );
+
+
+
+
+
+	// prepare the cursor 25D packet
+	fullPacket->Clear();
+	(*fullPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/25Dcur") << "source" << source_name << osc::EndMessage;
+	// add the cursor 25D alive message
+	(*fullPacket) << osc::BeginMessage("/tuio/25Dcur") << "alive";
+	for (std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin(); tuioCursor != cursor25DList.end(); tuioCursor++)
+		(*fullPacket) << (int32)((*tuioCursor)->getSessionID());
+	(*fullPacket) << osc::EndMessage;
+
+	// add all current cursor set messages
+	for (std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin(); tuioCursor != cursor25DList.end(); tuioCursor++) {
+
+		// start a new packet if we exceed the packet capacity
+		if ((fullPacket->Capacity() - fullPacket->Size()) < CUR25D_MESSAGE_SIZE) {
+
+			// add the immediate fseq message and send the cursor packet
+			(*fullPacket) << osc::BeginMessage("/tuio/25Dcur") << "fseq" << -1 << osc::EndMessage;
+			(*fullPacket) << osc::EndBundle;
+			deliverOscPacket(fullPacket);
+
+			// prepare the new cursor packet
+			fullPacket->Clear();
+			(*fullPacket) << osc::BeginBundleImmediate;
+			if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/25Dcur") << "source" << source_name << osc::EndMessage;
+			// add the cursor alive message
+			(*fullPacket) << osc::BeginMessage("/tuio/25Dcur") << "alive";
+			for (std::list<TuioCursor25D*>::iterator tuioCursor = cursor25DList.begin(); tuioCursor != cursor25DList.end(); tuioCursor++)
+				(*fullPacket) << (int32)((*tuioCursor)->getSessionID());
+			(*fullPacket) << osc::EndMessage;
+		}
+
+		float xpos = (*tuioCursor)->getX();
+		float xvel = (*tuioCursor)->getXSpeed();
+		if (invert_x) {
+			xpos = 1 - xpos;
+			xvel = -1 * xvel;
+		}
+		float ypos = (*tuioCursor)->getY();
+		float yvel = (*tuioCursor)->getYSpeed();
+		if (invert_y) {
+			ypos = 1 - ypos;
+			yvel = -1 * yvel;
+		}
+		float zpos = (*tuioCursor)->getZ();
+		float zvel = (*tuioCursor)->getZSpeed();
+		if (invert_z) {
+			zpos = 1 - zpos;
+			zvel = -1 * zvel;
+		}
+
+		// add the actual cursor set message
+		(*fullPacket) << osc::BeginMessage("/tuio/25Dcur") << "set";
+		(*fullPacket) << (int32)((*tuioCursor)->getSessionID()) << xpos << ypos << zpos;
+		(*fullPacket) << xvel << yvel << zvel << (*tuioCursor)->getMotionAccel();
+		(*fullPacket) << osc::EndMessage;
+	}
+
+	// add the immediate fseq message and send the cursor packet
+	(*fullPacket) << osc::BeginMessage("/tuio/25Dcur") << "fseq" << -1 << osc::EndMessage;
+	(*fullPacket) << osc::EndBundle;
+	deliverOscPacket(fullPacket);
+
+	// prepare the object 25D packet
+	fullPacket->Clear();
+	(*fullPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/25Dobj") << "source" << source_name << osc::EndMessage;
+	// add the object alive message
+	(*fullPacket) << osc::BeginMessage("/tuio/25Dobj") << "alive";
+	for (std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin(); tuioObject != object25DList.end(); tuioObject++)
+		(*fullPacket) << (int32)((*tuioObject)->getSessionID());
+	(*fullPacket) << osc::EndMessage;
+
+	for (std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin(); tuioObject != object25DList.end(); tuioObject++) {
+
+		// start a new packet if we exceed the packet capacity
+		if ((fullPacket->Capacity() - fullPacket->Size()) < OBJ25D_MESSAGE_SIZE) {
+			// add the immediate fseq message and send the object packet
+			(*fullPacket) << osc::BeginMessage("/tuio/25Dobj") << "fseq" << -1 << osc::EndMessage;
+			(*fullPacket) << osc::EndBundle;
+			deliverOscPacket(fullPacket);
+
+			// prepare the new object packet
+			fullPacket->Clear();
+			(*fullPacket) << osc::BeginBundleImmediate;
+			if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/25Dobj") << "source" << source_name << osc::EndMessage;
+			// add the object alive message
+			(*fullPacket) << osc::BeginMessage("/tuio/25Dobj") << "alive";
+			for (std::list<TuioObject25D*>::iterator tuioObject = object25DList.begin(); tuioObject != object25DList.end(); tuioObject++)
+				(*fullPacket) << (int32)((*tuioObject)->getSessionID());
+			(*fullPacket) << osc::EndMessage;
+		}
+
+		float xpos = (*tuioObject)->getX();
+		float xvel = (*tuioObject)->getXSpeed();
+		if (invert_x) {
+			xpos = 1 - xpos;
+			xvel = -1 * xvel;
+		}
+		float ypos = (*tuioObject)->getY();
+		float yvel = (*tuioObject)->getYSpeed();
+		if (invert_y) {
+			ypos = 1 - ypos;
+			yvel = -1 * yvel;
+		}
+		float zpos = (*tuioObject)->getZ();
+		float zvel = (*tuioObject)->getZSpeed();
+		if (invert_z) {
+			zpos = 1 - zpos;
+			zvel = -1 * zvel;
+		}
+		float angle = (*tuioObject)->getAngle();
+		float rvel = (*tuioObject)->getRotationSpeed();
+		if (invert_a) {
+			angle = 2.0f*(float)M_PI - angle;
+			rvel = -1 * rvel;
+		}
+
+		// add the actual object set message
+		(*fullPacket) << osc::BeginMessage("/tuio/25Dobj") << "set";
+		(*fullPacket) << (int32)((*tuioObject)->getSessionID()) << (*tuioObject)->getSymbolID() << xpos << ypos << zpos << angle;
+		(*fullPacket) << xvel << yvel << zvel << rvel << (*tuioObject)->getMotionAccel() << (*tuioObject)->getRotationAccel();
+		(*fullPacket) << osc::EndMessage;
+
+	}
+	// add the immediate fseq message and send the object packet
+	(*fullPacket) << osc::BeginMessage("/tuio/25Dobj") << "fseq" << -1 << osc::EndMessage;
+	(*fullPacket) << osc::EndBundle;
+	deliverOscPacket(fullPacket);
+
+	// prepare the 25D blob packet
+	fullPacket->Clear();
+	(*fullPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/25Dblb") << "source" << source_name << osc::EndMessage;
+	// add the object alive message
+	(*fullPacket) << osc::BeginMessage("/tuio/25Dblb") << "alive";
+	for (std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin(); tuioBlob != blob25DList.end(); tuioBlob++)
+		(*fullPacket) << (int32)((*tuioBlob)->getSessionID());
+	(*fullPacket) << osc::EndMessage;
+
+	for (std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin(); tuioBlob != blob25DList.end(); tuioBlob++) {
+
+		// start a new packet if we exceed the packet capacity
+		if ((fullPacket->Capacity() - fullPacket->Size()) < BLB25D_MESSAGE_SIZE) {
+			// add the immediate fseq message and send the object packet
+			(*fullPacket) << osc::BeginMessage("/tuio/25Dblb") << "fseq" << -1 << osc::EndMessage;
+			(*fullPacket) << osc::EndBundle;
+			deliverOscPacket(fullPacket);
+
+			// prepare the new blob packet
+			fullPacket->Clear();
+			(*fullPacket) << osc::BeginBundleImmediate;
+			if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/25Dblb") << "source" << source_name << osc::EndMessage;
+			// add the blob alive message
+			(*fullPacket) << osc::BeginMessage("/tuio/25Dblb") << "alive";
+			for (std::list<TuioBlob25D*>::iterator tuioBlob = blob25DList.begin(); tuioBlob != blob25DList.end(); tuioBlob++)
+				(*fullPacket) << (int32)((*tuioBlob)->getSessionID());
+			(*fullPacket) << osc::EndMessage;
+		}
+
+		float xpos = (*tuioBlob)->getX();
+		float xvel = (*tuioBlob)->getXSpeed();
+		if (invert_x) {
+			xpos = 1 - xpos;
+			xvel = -1 * xvel;
+		}
+		float ypos = (*tuioBlob)->getY();
+		float yvel = (*tuioBlob)->getYSpeed();
+		if (invert_y) {
+			ypos = 1 - ypos;
+			yvel = -1 * yvel;
+		}
+		float zpos = (*tuioBlob)->getZ();
+		float zvel = (*tuioBlob)->getZSpeed();
+		if (invert_z) {
+			zpos = 1 - zpos;
+			zvel = -1 * zvel;
+		}
+		float angle = (*tuioBlob)->getAngle();
+		float rvel = (*tuioBlob)->getRotationSpeed();
+		if (invert_a) {
+			angle = 2.0f*(float)M_PI - angle;
+			rvel = -1 * rvel;
+		}
+
+		// add the actual blob set message
+		(*fullPacket) << osc::BeginMessage("/tuio/25Dblb") << "set";
+		(*fullPacket) << (int32)((*tuioBlob)->getSessionID()) << xpos << ypos << zpos << angle << (*tuioBlob)->getWidth() << (*tuioBlob)->getHeight() << (*tuioBlob)->getArea();
+		(*fullPacket) << xvel << yvel << zvel << rvel << (*tuioBlob)->getMotionAccel() << (*tuioBlob)->getRotationAccel();
+		(*fullPacket) << osc::EndMessage;
+
+	}
+	// add the immediate fseq message and send the blob packet
+	(*fullPacket) << osc::BeginMessage("/tuio/25Dblb") << "fseq" << -1 << osc::EndMessage;
+	(*fullPacket) << osc::EndBundle;
+	deliverOscPacket(fullPacket);
+
+
+
+
+
+
+
+
+
+
+
+
+	// prepare the cursor 3D packet
+	fullPacket->Clear();
+	(*fullPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/3Dcur") << "source" << source_name << osc::EndMessage;
+	// add the cursor 3D alive message
+	(*fullPacket) << osc::BeginMessage("/tuio/3Dcur") << "alive";
+	for (std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin(); tuioCursor != cursor3DList.end(); tuioCursor++)
+		(*fullPacket) << (int32)((*tuioCursor)->getSessionID());
+	(*fullPacket) << osc::EndMessage;
+
+	// add all current cursor set messages
+	for (std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin(); tuioCursor != cursor3DList.end(); tuioCursor++) {
+
+		// start a new packet if we exceed the packet capacity
+		if ((fullPacket->Capacity() - fullPacket->Size()) < CUR3D_MESSAGE_SIZE) {
+
+			// add the immediate fseq message and send the cursor packet
+			(*fullPacket) << osc::BeginMessage("/tuio/3Dcur") << "fseq" << -1 << osc::EndMessage;
+			(*fullPacket) << osc::EndBundle;
+			deliverOscPacket(fullPacket);
+
+			// prepare the new cursor packet
+			fullPacket->Clear();
+			(*fullPacket) << osc::BeginBundleImmediate;
+			if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/3Dcur") << "source" << source_name << osc::EndMessage;
+			// add the cursor alive message
+			(*fullPacket) << osc::BeginMessage("/tuio/3Dcur") << "alive";
+			for (std::list<TuioCursor3D*>::iterator tuioCursor = cursor3DList.begin(); tuioCursor != cursor3DList.end(); tuioCursor++)
+				(*fullPacket) << (int32)((*tuioCursor)->getSessionID());
+			(*fullPacket) << osc::EndMessage;
+		}
+
+		float xpos = (*tuioCursor)->getX();
+		float xvel = (*tuioCursor)->getXSpeed();
+		if (invert_x) {
+			xpos = 1 - xpos;
+			xvel = -1 * xvel;
+		}
+		float ypos = (*tuioCursor)->getY();
+		float yvel = (*tuioCursor)->getYSpeed();
+		if (invert_y) {
+			ypos = 1 - ypos;
+			yvel = -1 * yvel;
+		}
+		float zpos = (*tuioCursor)->getZ();
+		float zvel = (*tuioCursor)->getZSpeed();
+		if (invert_z) {
+			zpos = 1 - zpos;
+			zvel = -1 * zvel;
+		}
+
+		// add the actual cursor set message
+		(*fullPacket) << osc::BeginMessage("/tuio/3Dcur") << "set";
+		(*fullPacket) << (int32)((*tuioCursor)->getSessionID()) << xpos << ypos << zpos;
+		(*fullPacket) << xvel << yvel << zvel << (*tuioCursor)->getMotionAccel();
+		(*fullPacket) << osc::EndMessage;
+	}
+
+	// add the immediate fseq message and send the cursor packet
+	(*fullPacket) << osc::BeginMessage("/tuio/3Dcur") << "fseq" << -1 << osc::EndMessage;
+	(*fullPacket) << osc::EndBundle;
+	deliverOscPacket(fullPacket);
+
+	// prepare the object 3D packet
+	fullPacket->Clear();
+	(*fullPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/3Dobj") << "source" << source_name << osc::EndMessage;
+	// add the object alive message
+	(*fullPacket) << osc::BeginMessage("/tuio/3Dobj") << "alive";
+	for (std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin(); tuioObject != object3DList.end(); tuioObject++)
+		(*fullPacket) << (int32)((*tuioObject)->getSessionID());
+	(*fullPacket) << osc::EndMessage;
+
+	for (std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin(); tuioObject != object3DList.end(); tuioObject++) {
+
+		// start a new packet if we exceed the packet capacity
+		if ((fullPacket->Capacity() - fullPacket->Size()) < OBJ3D_MESSAGE_SIZE) {
+			// add the immediate fseq message and send the object packet
+			(*fullPacket) << osc::BeginMessage("/tuio/3Dobj") << "fseq" << -1 << osc::EndMessage;
+			(*fullPacket) << osc::EndBundle;
+			deliverOscPacket(fullPacket);
+
+			// prepare the new object packet
+			fullPacket->Clear();
+			(*fullPacket) << osc::BeginBundleImmediate;
+			if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/3Dobj") << "source" << source_name << osc::EndMessage;
+			// add the object alive message
+			(*fullPacket) << osc::BeginMessage("/tuio/3Dobj") << "alive";
+			for (std::list<TuioObject3D*>::iterator tuioObject = object3DList.begin(); tuioObject != object3DList.end(); tuioObject++)
+				(*fullPacket) << (int32)((*tuioObject)->getSessionID());
+			(*fullPacket) << osc::EndMessage;
+		}
+
+		float xpos = (*tuioObject)->getX();
+		float xvel = (*tuioObject)->getXSpeed();
+		if (invert_x) {
+			xpos = 1 - xpos;
+			xvel = -1 * xvel;
+		}
+		float ypos = (*tuioObject)->getY();
+		float yvel = (*tuioObject)->getYSpeed();
+		if (invert_y) {
+			ypos = 1 - ypos;
+			yvel = -1 * yvel;
+		}
+		float zpos = (*tuioObject)->getZ();
+		float zvel = (*tuioObject)->getZSpeed();
+		if (invert_z) {
+			zpos = 1 - zpos;
+			zvel = -1 * zvel;
+		}
+		float roll = (*tuioObject)->getRoll();
+		float rollvel = (*tuioObject)->getRollSpeed();
+		if (invert_a) {
+			roll = 2.0f*(float)M_PI - roll;
+			rollvel = -1 * rollvel;
+		}
+		float pitch = (*tuioObject)->getPitch();
+		float pitchvel = (*tuioObject)->getPitchSpeed();
+		if (invert_b) {
+			pitch = 2.0f*(float)M_PI - pitch;
+			pitchvel = -1 * pitchvel;
+		}
+		float yaw = (*tuioObject)->getYaw();
+		float yawvel = (*tuioObject)->getYawSpeed();
+		if (invert_c) {
+			yaw = 2.0f*(float)M_PI - yaw;
+			yawvel = -1 * yawvel;
+		}
+
+		// add the actual object set message
+		(*fullPacket) << osc::BeginMessage("/tuio/3Dobj") << "set";
+		(*fullPacket) << (int32)((*tuioObject)->getSessionID()) << (*tuioObject)->getSymbolID() << xpos << ypos << zpos << roll << pitch << yaw;
+		(*fullPacket) << xvel << yvel << zvel << rollvel << pitchvel << yawvel << (*tuioObject)->getMotionAccel() << (*tuioObject)->getRotationAccel();
+		(*fullPacket) << osc::EndMessage;
+
+	}
+	// add the immediate fseq message and send the object packet
+	(*fullPacket) << osc::BeginMessage("/tuio/3Dobj") << "fseq" << -1 << osc::EndMessage;
+	(*fullPacket) << osc::EndBundle;
+	deliverOscPacket(fullPacket);
+
+	// prepare the 3D blob packet
+	fullPacket->Clear();
+	(*fullPacket) << osc::BeginBundleImmediate;
+	if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/3Dblb") << "source" << source_name << osc::EndMessage;
+	// add the object alive message
+	(*fullPacket) << osc::BeginMessage("/tuio/3Dblb") << "alive";
+	for (std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin(); tuioBlob != blob3DList.end(); tuioBlob++)
+		(*fullPacket) << (int32)((*tuioBlob)->getSessionID());
+	(*fullPacket) << osc::EndMessage;
+
+	for (std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin(); tuioBlob != blob3DList.end(); tuioBlob++) {
+
+		// start a new packet if we exceed the packet capacity
+		if ((fullPacket->Capacity() - fullPacket->Size()) < BLB3D_MESSAGE_SIZE) {
+			// add the immediate fseq message and send the object packet
+			(*fullPacket) << osc::BeginMessage("/tuio/3Dblb") << "fseq" << -1 << osc::EndMessage;
+			(*fullPacket) << osc::EndBundle;
+			deliverOscPacket(fullPacket);
+
+			// prepare the new blob packet
+			fullPacket->Clear();
+			(*fullPacket) << osc::BeginBundleImmediate;
+			if (source_name) (*fullPacket) << osc::BeginMessage("/tuio/3Dblb") << "source" << source_name << osc::EndMessage;
+			// add the blob alive message
+			(*fullPacket) << osc::BeginMessage("/tuio/3Dblb") << "alive";
+			for (std::list<TuioBlob3D*>::iterator tuioBlob = blob3DList.begin(); tuioBlob != blob3DList.end(); tuioBlob++)
+				(*fullPacket) << (int32)((*tuioBlob)->getSessionID());
+			(*fullPacket) << osc::EndMessage;
+		}
+
+		float xpos = (*tuioBlob)->getX();
+		float xvel = (*tuioBlob)->getXSpeed();
+		if (invert_x) {
+			xpos = 1 - xpos;
+			xvel = -1 * xvel;
+		}
+		float ypos = (*tuioBlob)->getY();
+		float yvel = (*tuioBlob)->getYSpeed();
+		if (invert_y) {
+			ypos = 1 - ypos;
+			yvel = -1 * yvel;
+		}
+		float zpos = (*tuioBlob)->getZ();
+		float zvel = (*tuioBlob)->getZSpeed();
+		if (invert_z) {
+			zpos = 1 - zpos;
+			zvel = -1 * zvel;
+		}
+		float roll = (*tuioBlob)->getRoll();
+		float rollvel = (*tuioBlob)->getRollSpeed();
+		if (invert_a) {
+			roll = 2.0f*(float)M_PI - roll;
+			rollvel = -1 * rollvel;
+		}
+		float pitch = (*tuioBlob)->getPitch();
+		float pitchvel = (*tuioBlob)->getPitchSpeed();
+		if (invert_b) {
+			pitch = 2.0f*(float)M_PI - pitch;
+			pitchvel = -1 * pitchvel;
+		}
+		float yaw = (*tuioBlob)->getYaw();
+		float yawvel = (*tuioBlob)->getYawSpeed();
+		if (invert_c) {
+			yaw = 2.0f*(float)M_PI - yaw;
+			yawvel = -1 * yawvel;
+		}
+
+		// add the actual blob set message
+		(*fullPacket) << osc::BeginMessage("/tuio/3Dblb") << "set";
+		(*fullPacket) << (int32)((*tuioBlob)->getSessionID()) << xpos << ypos << zpos << roll << pitch << yaw << (*tuioBlob)->getWidth() << (*tuioBlob)->getHeight() << (*tuioBlob)->getDepth() << (*tuioBlob)->getVolume();
+		(*fullPacket) << xvel << yvel << zvel << rollvel << pitchvel << yawvel << (*tuioBlob)->getMotionAccel() << (*tuioBlob)->getRotationAccel();
+		(*fullPacket) << osc::EndMessage;
+
+	}
+	// add the immediate fseq message and send the blob packet
+	(*fullPacket) << osc::BeginMessage("/tuio/3Dblb") << "fseq" << -1 << osc::EndMessage;
+	(*fullPacket) << osc::EndBundle;
+	deliverOscPacket(fullPacket);
+
+
+
+
+
+
 }
 
 

--- a/TUIO/TuioServer.h
+++ b/TUIO/TuioServer.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ Library
- Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -66,7 +67,7 @@ namespace TUIO {
 	 * </code></p>
 	 *
 	 * @author Martin Kaltenbrunner
-	 * @version 1.1.6
+	 * @version 1.1.7
 	 */
 	class LIBDECL TuioServer : public TuioManager {
 

--- a/TUIO/TuioServer.h
+++ b/TUIO/TuioServer.h
@@ -1,17 +1,17 @@
 /*
  TUIO C++ Library
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 2022 Nicolas Bremard <nicolas.bremard@laposte.net>
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 3.0 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library.
 */
@@ -194,6 +194,22 @@ namespace TUIO {
 		bool hasCursorProfile() { return cursorProfileEnabled; };
 		bool hasBlobProfile() { return blobProfileEnabled; };
 
+		void enableObject25DProfile(bool flag) { object25DProfileEnabled = flag; };
+		void enableCursor25DProfile(bool flag) { cursor25DProfileEnabled = flag; };
+		void enableBlob25DProfile(bool flag) { blob25DProfileEnabled = flag; };
+
+		bool hasObject25DProfile() { return object25DProfileEnabled; };
+		bool hasCursor25DProfile() { return cursor25DProfileEnabled; };
+		bool hasBlob25DProfile() { return blob25DProfileEnabled; };
+
+		void enableObject3DProfile(bool flag) { object3DProfileEnabled = flag; };
+		void enableCursor3DProfile(bool flag) { cursor3DProfileEnabled = flag; };
+		void enableBlob3DProfile(bool flag) { blob3DProfileEnabled = flag; };
+
+		bool hasObject3DProfile() { return object3DProfileEnabled; };
+		bool hasCursor3DProfile() { return cursor3DProfileEnabled; };
+		bool hasBlob3DProfile() { return blob3DProfileEnabled; };
+
 	private:
 
 		void initialize(OscSender *oscsend);
@@ -221,10 +237,46 @@ namespace TUIO {
 		void sendBlobBundle(long fseq);
 		void sendEmptyBlobBundle();
 
+		void startObject25DBundle();
+		void addObject25DMessage(TuioObject25D *tobj);
+		void sendObject25DBundle(long fseq);
+		void sendEmptyObject25DBundle();
+
+		void startCursor25DBundle();
+		void addCursor25DMessage(TuioCursor25D *tcur);
+		void sendCursor25DBundle(long fseq);
+		void sendEmptyCursor25DBundle();
+
+		void startBlob25DBundle();
+		void addBlob25DMessage(TuioBlob25D *tblb);
+		void sendBlob25DBundle(long fseq);
+		void sendEmptyBlob25DBundle();
+
+
+		void startObject3DBundle();
+		void addObject3DMessage(TuioObject3D *tobj);
+		void sendObject3DBundle(long fseq);
+		void sendEmptyObject3DBundle();
+
+		void startCursor3DBundle();
+		void addCursor3DMessage(TuioCursor3D *tcur);
+		void sendCursor3DBundle(long fseq);
+		void sendEmptyCursor3DBundle();
+
+		void startBlob3DBundle();
+		void addBlob3DMessage(TuioBlob3D *tblb);
+		void sendBlob3DBundle(long fseq);
+		void sendEmptyBlob3DBundle();
+
+
 		int update_interval;
 		bool full_update, periodic_update;
 		TuioTime objectUpdateTime, cursorUpdateTime, blobUpdateTime ;
 		bool objectProfileEnabled, cursorProfileEnabled, blobProfileEnabled;
+		TuioTime object25DUpdateTime, cursor25DUpdateTime, blob25DUpdateTime;
+		bool object25DProfileEnabled, cursor25DProfileEnabled, blob25DProfileEnabled;
+		TuioTime object3DUpdateTime, cursor3DUpdateTime, blob3DUpdateTime;
+		bool object3DProfileEnabled, cursor3DProfileEnabled, blob3DProfileEnabled;
 		char *source_name;
 	};
 }

--- a/TuioDemo.cpp
+++ b/TuioDemo.cpp
@@ -1,6 +1,7 @@
 /*
  TUIO C++ GUI Demo
- Copyright (c) 
+ Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/TuioDemo.cpp
+++ b/TuioDemo.cpp
@@ -1,17 +1,17 @@
 /*
  TUIO C++ GUI Demo
- Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
- 
+ Copyright (c) 
+
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 2 of the License, or
  (at your option) any later version.
- 
+
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with this program; if not, write to the Free Software
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -27,59 +27,171 @@ static int _port = 3333;
 
 void TuioDemo::addTuioObject(TuioObject *tobj) {
 	if (verbose)
-		std::cout << "add obj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/"<<  tobj->getTuioSourceID() << ") "<< tobj->getX() << " " << tobj->getY() << " " << tobj->getAngle() << std::endl;
+		std::cout << "add obj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getAngle() << std::endl;
 }
 
 void TuioDemo::updateTuioObject(TuioObject *tobj) {
-	
+
 	if (verbose)
-		std::cout << "set obj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/"<<  tobj->getTuioSourceID() << ") "<< tobj->getX() << " " << tobj->getY() << " " << tobj->getAngle() 
+		std::cout << "set obj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getAngle()
 		<< " " << tobj->getMotionSpeed() << " " << tobj->getRotationSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
 }
 
 void TuioDemo::removeTuioObject(TuioObject *tobj) {
-	
+
 	if (verbose)
-		std::cout << "del obj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/"<<  tobj->getTuioSourceID() << ")" << std::endl;
+		std::cout << "del obj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ")" << std::endl;
 }
 
 void TuioDemo::addTuioCursor(TuioCursor *tcur) {
-	
+
 	if (verbose)
-		std::cout << "add cur " << tcur->getCursorID() << " (" <<  tcur->getSessionID() << "/"<<  tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << std::endl;
+		std::cout << "add cur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << std::endl;
 }
 
 void TuioDemo::updateTuioCursor(TuioCursor *tcur) {
-	
+
 	if (verbose)
-		std::cout << "set cur " << tcur->getCursorID() << " (" <<  tcur->getSessionID() << "/"<<  tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() 
+		std::cout << "set cur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY()
 		<< " " << tcur->getMotionSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
 }
 
 void TuioDemo::removeTuioCursor(TuioCursor *tcur) {
-	
+
 	if (verbose)
-		std::cout << "del cur " << tcur->getCursorID() << " (" <<  tcur->getSessionID() << "/"<<  tcur->getTuioSourceID() << ")" << std::endl;
+		std::cout << "del cur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ")" << std::endl;
 }
 
 void TuioDemo::addTuioBlob(TuioBlob *tblb) {
-	
+
 	if (verbose)
-		std::cout << "add blb " << tblb->getBlobID() << " (" << tblb->getSessionID()  << "/"<<  tblb->getTuioSourceID()<< ") "<< tblb->getX() << " " << tblb->getY() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea() << std::endl;
+		std::cout << "add blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea() << std::endl;
 }
 
 void TuioDemo::updateTuioBlob(TuioBlob *tblb) {
-	
+
 	if (verbose)
-		std::cout << "set blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/"<<  tblb->getTuioSourceID() << ") "<< tblb->getX() << " " << tblb->getY() << " " << tblb->getAngle() << " "<< tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea() 
+		std::cout << "set blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea()
 		<< " " << tblb->getMotionSpeed() << " " << tblb->getRotationSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << std::endl;
 }
 
 void TuioDemo::removeTuioBlob(TuioBlob *tblb) {
-	
+
 	if (verbose)
-		std::cout << "del blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/"<<  tblb->getTuioSourceID() << ")" << std::endl;
+		std::cout << "del blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ")" << std::endl;
 }
+
+
+
+
+
+
+void TuioDemo::addTuioObject25D(TuioObject25D *tobj) {
+	if (verbose)
+	std::cout << "add 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getAngle() << std::endl;
+}
+
+void TuioDemo::updateTuioObject25D(TuioObject25D *tobj) {
+	if (verbose)
+	std::cout << "set 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getAngle()
+		<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRotationSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+}
+
+void TuioDemo::removeTuioObject25D(TuioObject25D *tobj) {
+	if (verbose)
+	std::cout << "del 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ")" << std::endl;
+}
+
+void TuioDemo::addTuioCursor25D(TuioCursor25D *tcur) {
+	if (verbose)
+	std::cout << "add 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ() << std::endl;
+}
+
+void TuioDemo::updateTuioCursor25D(TuioCursor25D *tcur) {
+	if (verbose)
+	std::cout << "set 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+		<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+}
+
+void TuioDemo::removeTuioCursor25D(TuioCursor25D *tcur) {
+	if (verbose)
+	std::cout << "del 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ")" << std::endl;
+}
+
+void TuioDemo::addTuioBlob25D(TuioBlob25D *tblb) {
+	if (verbose)
+	std::cout << "add 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea() << std::endl;
+}
+
+void TuioDemo::updateTuioBlob25D(TuioBlob25D *tblb) {
+	if (verbose)
+	std::cout << "set 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea()
+		<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRotationSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << std::endl;
+}
+
+void TuioDemo::removeTuioBlob25D(TuioBlob25D *tblb) {
+	if (verbose)
+	std::cout << "del 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ")" << std::endl;
+}
+
+
+
+
+void TuioDemo::addTuioObject3D(TuioObject3D *tobj) {
+	if (verbose)
+	std::cout << "add 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getRoll() << " " << tobj->getPitch() << " " << tobj->getYaw() << std::endl;
+}
+
+void TuioDemo::updateTuioObject3D(TuioObject3D *tobj) {
+	if (verbose)
+	std::cout << "set 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getRoll() << " " << tobj->getPitch() << " " << tobj->getYaw()
+		<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRollSpeed() << " " << tobj->getPitchSpeed() << " " << tobj->getYawSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+}
+
+void TuioDemo::removeTuioObject3D(TuioObject3D *tobj) {
+	if (verbose)
+	std::cout << "del 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ")" << std::endl;
+}
+
+void TuioDemo::addTuioCursor3D(TuioCursor3D *tcur) {
+	if (verbose)
+	std::cout << "add 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ() << std::endl;
+}
+
+void TuioDemo::updateTuioCursor3D(TuioCursor3D *tcur) {
+	if (verbose)
+	std::cout << "set 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+		<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+}
+
+void TuioDemo::removeTuioCursor3D(TuioCursor3D *tcur) {
+	if (verbose)
+	std::cout << "del 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ")" << std::endl;
+}
+
+void TuioDemo::addTuioBlob3D(TuioBlob3D *tblb) {
+	if (verbose)
+	std::cout << "add 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getRoll() << " " << tblb->getPitch() << " " << tblb->getYaw() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getDepth() << " " << tblb->getVolume() << std::endl;
+}
+
+void TuioDemo::updateTuioBlob3D(TuioBlob3D *tblb) {
+	if (verbose)
+	std::cout << "set 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getRoll() << " " << tblb->getPitch() << " " << tblb->getYaw() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getDepth() << " " << tblb->getVolume()
+		<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRollSpeed() << " " << tblb->getPitchSpeed() << " " << tblb->getYawSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << std::endl;
+}
+
+void TuioDemo::removeTuioBlob3D(TuioBlob3D *tblb) {
+	if (verbose)
+	std::cout << "del 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ")" << std::endl;
+}
+
+
+
+
+
+
+
+
 
 
 void TuioDemo::refresh(TuioTime frameTime) {
@@ -94,50 +206,50 @@ void TuioDemo::drawObjects() {
 	// draw the cursors
 	std::list<TuioCursor*> cursorList = tuioClient->getTuioCursors();
 	tuioClient->lockCursorList();
-	for (std::list<TuioCursor*>::iterator iter = cursorList.begin(); iter!=cursorList.end(); iter++) {
+	for (std::list<TuioCursor*>::iterator iter = cursorList.begin(); iter != cursorList.end(); iter++) {
 		TuioCursor *tuioCursor = (*iter);
 		std::list<TuioPoint> path = tuioCursor->getPath();
-		if (path.size()>0) {
-			
+		if (path.size() > 0) {
+
 			TuioPoint last_point = path.front();
 			glBegin(GL_LINES);
 			glColor3f(0.0, 0.0, 1.0);
-			
-			for (std::list<TuioPoint>::iterator point = path.begin(); point!=path.end(); point++) {
+
+			for (std::list<TuioPoint>::iterator point = path.begin(); point != path.end(); point++) {
 				glVertex3f(last_point.getScreenX(width), last_point.getScreenY(height), 0.0f);
 				glVertex3f(point->getScreenX(width), point->getScreenY(height), 0.0f);
-				last_point.update(point->getX(),point->getY());
+				last_point.update(point->getX(), point->getY());
 			} glEnd();
-			
+
 			// draw the finger tip
 			glColor3f(0.75, 0.0, 0.75);
 			glPushMatrix();
 			glTranslatef(last_point.getScreenX(width), last_point.getScreenY(height), 0.0);
 			glBegin(GL_TRIANGLE_FAN);
-			for(double a = 0.0f; a <= 2*M_PI; a += 0.2f) {
-				glVertex2d(cos(a) * height/100.0f, sin(a) * height/100.0f);
+			for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+				glVertex2d(cos(a) * height / 100.0f, sin(a) * height / 100.0f);
 			} glEnd();
 			glPopMatrix();
-			
+
 			glColor3f(1.0, 1.0, 1.0);
-			glRasterPos2f(tuioCursor->getScreenX(width),tuioCursor->getScreenY(height));
-			sprintf(id,"%d",tuioCursor->getCursorID());
+			glRasterPos2f(tuioCursor->getScreenX(width), tuioCursor->getScreenY(height));
+			sprintf(id, "%d", tuioCursor->getCursorID());
 			drawString(id);
 		}
 	}
 	tuioClient->unlockCursorList();
-	
+
 	// draw the objects
 	std::list<TuioObject*> objectList = tuioClient->getTuioObjects();
 	tuioClient->lockObjectList();
-	for (std::list<TuioObject*>::iterator iter = objectList.begin(); iter!=objectList.end(); iter++) {
+	for (std::list<TuioObject*>::iterator iter = objectList.begin(); iter != objectList.end(); iter++) {
 		TuioObject *tuioObject = (*iter);
-		int pos_size = height/20.0f;
-		int neg_size = -1*pos_size;
-		float xpos  = tuioObject->getScreenX(width);
-		float ypos  = tuioObject->getScreenY(height);
+		int pos_size = height / 20.0f;
+		int neg_size = -1 * pos_size;
+		float xpos = tuioObject->getScreenX(width);
+		float ypos = tuioObject->getScreenY(height);
 		float angle = tuioObject->getAngleDegrees();
-		
+
 		glColor3f(0.25, 0.0, 0.0);
 		glPushMatrix();
 		glTranslatef(xpos, ypos, 0.0);
@@ -149,51 +261,253 @@ void TuioDemo::drawObjects() {
 		glVertex2f(pos_size, neg_size);
 		glEnd();
 		glPopMatrix();
-		
+
 		glColor3f(1.0, 1.0, 1.0);
-		glRasterPos2f(xpos,ypos+5);
-		sprintf(id,"%d",tuioObject->getSymbolID());
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "%d", tuioObject->getSymbolID());
 		drawString(id);
 	}
 	tuioClient->unlockObjectList();
-	
+
 	// draw the blobs
 	std::list<TuioBlob*> blobList = tuioClient->getTuioBlobs();
 	tuioClient->lockBlobList();
-	for (std::list<TuioBlob*>::iterator iter = blobList.begin(); iter!=blobList.end(); iter++) {
+	for (std::list<TuioBlob*>::iterator iter = blobList.begin(); iter != blobList.end(); iter++) {
 		TuioBlob *tuioBlob = (*iter);
-		float blob_width = tuioBlob->getScreenWidth(width)/2;
-		float blob_height = tuioBlob->getScreenHeight(height)/2;
-		float xpos  = tuioBlob->getScreenX(width);
-		float ypos  = tuioBlob->getScreenY(height);
+		float blob_width = tuioBlob->getScreenWidth(width) / 2;
+		float blob_height = tuioBlob->getScreenHeight(height) / 2;
+		float xpos = tuioBlob->getScreenX(width);
+		float ypos = tuioBlob->getScreenY(height);
 		float angle = tuioBlob->getAngleDegrees();
-		
+
 		glColor3f(0.25, 0.25, 0.25);
 		glPushMatrix();
 		glTranslatef(xpos, ypos, 0.0);
 		glRotatef(angle, 0.0, 0.0, 1.0);
-		
-		/*glBegin(GL_QUADS);
-		 glVertex2f(blob_width/-2, blob_height/-2);
-		 glVertex2f(blob_width/-2, blob_height/2);
-		 glVertex2f(blob_width/2, blob_height/2);
-		 glVertex2f(blob_width/2, blob_height/-2);
-		 glEnd();*/
-		
+
+
 		glBegin(GL_TRIANGLE_FAN);
-		for(double a = 0.0f; a <= 2*M_PI; a += 0.2f) {
+		for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
 			glVertex2d(cos(a) * blob_width, sin(a) * blob_height);
 		} glEnd();
-		
+
 		glPopMatrix();
-		
+
 		glColor3f(1.0, 1.0, 1.0);
-		glRasterPos2f(xpos,ypos+5);
-		sprintf(id,"%d",tuioBlob->getBlobID());
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "%d", tuioBlob->getBlobID());
 		drawString(id);
 	}
 	tuioClient->unlockBlobList();
-	
+
+
+
+	// draw the 25D cursors
+	std::list<TuioCursor25D*> cursor25DList = tuioClient->getTuioCursors25D();
+	tuioClient->lockCursor25DList();
+	for (std::list<TuioCursor25D*>::iterator iter = cursor25DList.begin(); iter != cursor25DList.end(); iter++) {
+		TuioCursor25D *tuioCursor = (*iter);
+		std::list<TuioPoint> path = tuioCursor->getPath();
+		if (path.size() > 0) {
+
+			TuioPoint last_point = path.front();
+			glBegin(GL_LINES);
+
+			for (std::list<TuioPoint>::iterator point = path.begin(); point != path.end(); point++) {
+
+				glColor3f(1.0 - point->getZ(), point->getZ(), 0.0); // change color according to Z coordinates from red (0) to green (1)
+
+				glVertex3f(last_point.getScreenX(width), last_point.getScreenY(height), 0.0f);
+				glVertex3f(point->getScreenX(width), point->getScreenY(height), 0.0f);
+				last_point.update(point->getX(), point->getY());
+			} glEnd();
+
+			// draw the finger tip
+			glColor3f(1.0 - last_point.getZ(),  last_point.getZ(), 0.0);
+			glPushMatrix();
+			glTranslatef(last_point.getScreenX(width), last_point.getScreenY(height), 0.0);
+			glBegin(GL_TRIANGLE_FAN);
+			for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+				glVertex2d(cos(a) * height / 100.0f, sin(a) * height / 100.0f);
+			} glEnd();
+			glPopMatrix();
+
+			glColor3f(1.0, 1.0, 1.0);
+			glRasterPos2f(tuioCursor->getScreenX(width), tuioCursor->getScreenY(height));
+			sprintf(id, "%d", tuioCursor->getCursorID());
+			drawString(id);
+		}
+	}
+	tuioClient->unlockCursor25DList();
+
+	// draw the objects
+	std::list<TuioObject25D*> object25DList = tuioClient->getTuioObjects25D();
+	tuioClient->lockObject25DList();
+	for (std::list<TuioObject25D*>::iterator iter = object25DList.begin(); iter != object25DList.end(); iter++) {
+		TuioObject25D *tuioObject = (*iter);
+		int pos_size = height / 20.0f;
+		int neg_size = -1 * pos_size;
+		float xpos = tuioObject->getScreenX(width);
+		float ypos = tuioObject->getScreenY(height);
+		float angle = tuioObject->getAngleDegrees();
+
+		glColor3f(1.0 - tuioObject->getZ(),  tuioObject->getZ(), 0.0);
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(angle, 0.0, 0.0, 1.0);
+		glBegin(GL_QUADS);
+		glVertex2f(neg_size, neg_size);
+		glVertex2f(neg_size, pos_size);
+		glVertex2f(pos_size, pos_size);
+		glVertex2f(pos_size, neg_size);
+		glEnd();
+		glPopMatrix();
+
+		glColor3f(1.0, 1.0, 1.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "%d", tuioObject->getSymbolID());
+		drawString(id);
+	}
+	tuioClient->unlockObject25DList();
+
+	// draw the blobs
+	std::list<TuioBlob25D*> blob25DList = tuioClient->getTuioBlobs25D();
+	tuioClient->lockBlob25DList();
+	for (std::list<TuioBlob25D*>::iterator iter = blob25DList.begin(); iter != blob25DList.end(); iter++) {
+		TuioBlob25D *tuioBlob = (*iter);
+		float blob_width = tuioBlob->getSpaceWidth(width) / 2;
+		float blob_height = tuioBlob->getSpaceHeight(height) / 2;
+		float xpos = tuioBlob->getScreenX(width);
+		float ypos = tuioBlob->getScreenY(height);
+		float angle = tuioBlob->getAngleDegrees();
+
+		glColor3f(1.0 - tuioBlob->getZ(), tuioBlob->getZ(), 0.0);
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(angle, 0.0, 0.0, 1.0);
+
+
+		glBegin(GL_TRIANGLE_FAN);
+		for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+			glVertex2d(cos(a) * blob_width, sin(a) * blob_height);
+		} glEnd();
+
+		glPopMatrix();
+
+		glColor3f(1.0, 1.0, 1.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "%d", tuioBlob->getBlobID());
+		drawString(id);
+	}
+	tuioClient->unlockBlob25DList();
+
+
+
+	// draw the 3D cursors
+	std::list<TuioCursor3D*> cursor3DList = tuioClient->getTuioCursors3D();
+	tuioClient->lockCursor3DList();
+	for (std::list<TuioCursor3D*>::iterator iter = cursor3DList.begin(); iter != cursor3DList.end(); iter++) {
+		TuioCursor3D *tuioCursor = (*iter);
+		std::list<TuioPoint> path = tuioCursor->getPath();
+		if (path.size() > 0) {
+
+			TuioPoint last_point = path.front();
+			glBegin(GL_LINES);
+
+			for (std::list<TuioPoint>::iterator point = path.begin(); point != path.end(); point++) {
+
+				glColor3f(1.0 - point->getZ(),  point->getZ(), 0.0); // change color according to Z coordinates from red (0) to green (1)
+
+				glVertex3f(last_point.getScreenX(width), last_point.getScreenY(height), 0.0f);
+				glVertex3f(point->getScreenX(width), point->getScreenY(height), 0.0f);
+				last_point.update(point->getX(), point->getY());
+			} glEnd();
+
+			// draw the finger tip
+			glColor3f(1.0 - last_point.getZ(), last_point.getZ(), 0.0);
+			glPushMatrix();
+			glTranslatef(last_point.getScreenX(width), last_point.getScreenY(height), 0.0);
+			glBegin(GL_TRIANGLE_FAN);
+			for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+				glVertex2d(cos(a) * height / 100.0f, sin(a) * height / 100.0f);
+			} glEnd();
+			glPopMatrix();
+
+			glColor3f(1.0, 1.0, 1.0);
+			glRasterPos2f(tuioCursor->getScreenX(width), tuioCursor->getScreenY(height));
+			sprintf(id, "%d", tuioCursor->getCursorID());
+			drawString(id);
+		}
+	}
+	tuioClient->unlockCursor3DList();
+
+	// draw the objects
+	std::list<TuioObject3D*> object3DList = tuioClient->getTuioObjects3D();
+	tuioClient->lockObject3DList();
+	for (std::list<TuioObject3D*>::iterator iter = object3DList.begin(); iter != object3DList.end(); iter++) {
+		TuioObject3D *tuioObject = (*iter);
+		int pos_size = height / 20.0f;
+		int neg_size = -1 * pos_size;
+		float xpos = tuioObject->getScreenX(width);
+		float ypos = tuioObject->getScreenY(height);
+		float roll = tuioObject->getRollDegrees();
+		float pitch = tuioObject->getPitchDegrees();
+		float yaw = tuioObject->getYawDegrees();
+
+		glColor3f(1.0 - tuioObject->getZ(),  tuioObject->getZ(), 0.0);
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(roll, pitch, yaw, 1.0);
+		glBegin(GL_QUADS);
+		glVertex2f(neg_size, neg_size);
+		glVertex2f(neg_size, pos_size);
+		glVertex2f(pos_size, pos_size);
+		glVertex2f(pos_size, neg_size);
+		glEnd();
+		glPopMatrix();
+
+		glColor3f(1.0, 1.0, 1.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "%d", tuioObject->getSymbolID());
+		drawString(id);
+	}
+	tuioClient->unlockObject3DList();
+
+	// draw the blobs
+	std::list<TuioBlob3D*> blob3DList = tuioClient->getTuioBlobs3D();
+	tuioClient->lockBlob3DList();
+	for (std::list<TuioBlob3D*>::iterator iter = blob3DList.begin(); iter != blob3DList.end(); iter++) {
+		TuioBlob3D *tuioBlob = (*iter);
+		float blob_width = tuioBlob->getSpaceWidth(width) / 2;
+		float blob_height = tuioBlob->getSpaceHeight(height) / 2;
+		float xpos = tuioBlob->getScreenX(width);
+		float ypos = tuioBlob->getScreenY(height);
+		float roll = tuioBlob->getRollDegrees();
+		float pitch = tuioBlob->getPitchDegrees();
+		float yaw = tuioBlob->getYawDegrees();
+
+		glColor3f(1.0 - tuioBlob->getZ(), tuioBlob->getZ(), 0.0);
+		glPushMatrix();
+		glTranslatef(xpos, ypos, 0.0);
+		glRotatef(roll, pitch, yaw, 1.0);
+
+		glBegin(GL_TRIANGLE_FAN);
+		for (double a = 0.0f; a <= 2 * M_PI; a += 0.2f) {
+			glVertex2d(cos(a) * blob_width, sin(a) * blob_height);
+		} glEnd();
+
+		glPopMatrix();
+
+		glColor3f(1.0, 1.0, 1.0);
+		glRasterPos2f(xpos, ypos + 5);
+		sprintf(id, "%d", tuioBlob->getBlobID());
+		drawString(id);
+	}
+	tuioClient->unlockBlob3DList();
+
+
+
+
 	SDL_GL_SwapWindow(window);
 }
 
@@ -207,29 +521,30 @@ void TuioDemo::drawString(char *str) {
 }
 
 void TuioDemo::initWindow() {
-	
+
 	SDL_DisplayMode mode;
 	SDL_GetCurrentDisplayMode(0, &mode);
 	screen_width = mode.w;
-	screen_height= mode.h;
-	
+	screen_height = mode.h;
+
 	int videoFlags = SDL_WINDOW_OPENGL;
-	if( fullscreen ) {
+	if (fullscreen) {
 		videoFlags |= SDL_WINDOW_FULLSCREEN;
 		width = screen_width;
 		height = screen_height;
-	} else {
+	}
+	else {
 		width = window_width;
 		height = window_height;
 	}
-	
+
 	SDL_CreateWindowAndRenderer(width, height, videoFlags, &window, &renderer);
 
-	if ( window == NULL ) {
+	if (window == NULL) {
 		std::cerr << "Could not open window: " << SDL_GetError() << std::endl;
 		SDL_Quit();
 	}
-	
+
 	SDL_GLContext context = SDL_GL_CreateContext(window);
 	if (!context) {
 		fprintf(stderr, "Couldn't create context: %s\n", SDL_GetError());
@@ -248,91 +563,93 @@ void TuioDemo::initWindow() {
 
 void TuioDemo::processEvents()
 {
-    SDL_Event event;
-	
-    while( SDL_PollEvent( &event ) ) {
+	SDL_Event event;
 
-        switch( event.type ) {
-			case SDL_KEYDOWN:
-				if (event.key.repeat) continue;
-				else if( event.key.keysym.sym == SDLK_ESCAPE ){
-					running = false;
-					SDL_ShowCursor(true);
-					SDL_Quit();
-				} else if( event.key.keysym.sym == SDLK_F1 ){
-					if(fullscreen)
-					{
-						width = window_width;
-						height = window_height;
-						SDL_SetWindowFullscreen(window, SDL_FALSE);
-						SDL_ShowCursor(1);
-						fullscreen = false;
-					}
-					else
-					{
-						SDL_ShowCursor(0);
-						width = screen_width;
-						height = screen_height;
-						SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-						fullscreen = true;
-					}
-					
-					glClearColor(0.0, 0.0, 0.25, 0.0);
-					glViewport(0, 0, (GLint)width, (GLint)height);
-					glMatrixMode(GL_PROJECTION);
-					glLoadIdentity();
-					gluOrtho2D(0, (GLfloat)width, (GLfloat)height, 0);
-					glMatrixMode(GL_MODELVIEW);
-					glLoadIdentity();
-					
-				} else if( event.key.keysym.sym == SDLK_v ){
-					verbose = !verbose;
-				}
-				
-				break;
-			case SDL_QUIT:
+	while (SDL_PollEvent(&event)) {
+
+		switch (event.type) {
+		case SDL_KEYDOWN:
+			if (event.key.repeat) continue;
+			else if (event.key.keysym.sym == SDLK_ESCAPE) {
 				running = false;
 				SDL_ShowCursor(true);
 				SDL_Quit();
-        }
-    }
+			}
+			else if (event.key.keysym.sym == SDLK_F1) {
+				if (fullscreen)
+				{
+					width = window_width;
+					height = window_height;
+					SDL_SetWindowFullscreen(window, SDL_FALSE);
+					SDL_ShowCursor(1);
+					fullscreen = false;
+				}
+				else
+				{
+					SDL_ShowCursor(0);
+					width = screen_width;
+					height = screen_height;
+					SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+					fullscreen = true;
+				}
+
+				glClearColor(0.0, 0.0, 0.25, 0.0);
+				glViewport(0, 0, (GLint)width, (GLint)height);
+				glMatrixMode(GL_PROJECTION);
+				glLoadIdentity();
+				gluOrtho2D(0, (GLfloat)width, (GLfloat)height, 0);
+				glMatrixMode(GL_MODELVIEW);
+				glLoadIdentity();
+
+			}
+			else if (event.key.keysym.sym == SDLK_v) {
+				verbose = !verbose;
+			}
+
+			break;
+		case SDL_QUIT:
+			running = false;
+			SDL_ShowCursor(true);
+			SDL_Quit();
+		}
+	}
 }
 
 TuioDemo::TuioDemo(const char *host, int port, bool udp, bool verb, bool full)
-: screen_width (1024)
-, screen_height (768)
-, window_width (640)
-, window_height (480)
-{	
+	: screen_width(1024)
+	, screen_height(768)
+	, window_width(640)
+	, window_height(480)
+{
 	verbose = verb;
 	fullscreen = full;
-	
+
 	if (udp) osc_receiver = new UdpReceiver(port);
 	else {
-		if (strcmp(host,"incoming")==0) osc_receiver = new TcpReceiver(port);
+		if (strcmp(host, "incoming") == 0) osc_receiver = new TcpReceiver(port);
 		else osc_receiver = new TcpReceiver(host, port);
 	}
-	
+
 	tuioClient = new TuioClient(osc_receiver);
 	tuioClient->addTuioListener(this);
 	tuioClient->connect();
-	
+
 	if (!tuioClient->isConnected()) {
 		SDL_Quit();
 	}
-	
-	if ( SDL_Init(SDL_INIT_VIDEO) < 0 ) {
-		std::cerr << "SDL could not be initialized: " <<  SDL_GetError() << std::endl;
+
+	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+		std::cerr << "SDL could not be initialized: " << SDL_GetError() << std::endl;
 		SDL_Quit();
 	}
-	
+
 
 	initWindow();
-	SDL_SetWindowTitle(window,"TuioDemo");
+	SDL_SetWindowTitle(window, "TuioDemo");
 }
 
 void TuioDemo::run() {
-	running=true;
+	running = true;
 	while (running) {
 		drawObjects();
 		processEvents();
@@ -357,29 +674,68 @@ static void init(int argc, char** argv) {
 #ifndef WIN32
 	while ((c = getopt(argc, argv, "p:a:tfvh")) != -1) {
 		switch (c) {
-			case 't':
-				_udp = false;
-				break;
-			case 'a':
-				_address = std::string(optarg);
-				break;
-			case 'p':
-				_port = atoi(optarg);
-				break;
-			case 'v':
-				_verbose = true;
-				break;
-			case 'f':
-				_fullscreen = true;
-				break;
-			case 'h':
-				show_help();
-				exit(0);
-			default:
-				show_help();
-				exit(1);
+		case 't':
+			_udp = false;
+			break;
+		case 'a':
+			_address = std::string(optarg);
+			break;
+		case 'p':
+			_port = atoi(optarg);
+			break;
+		case 'v':
+			_verbose = true;
+			break;
+		case 'f':
+			_fullscreen = true;
+			break;
+		case 'h':
+			show_help();
+			exit(0);
+		default:
+			show_help();
+			exit(1);
 		}
 	}
+
+#else
+
+	int index = 1;
+
+	while (index < argc)
+	{
+		c = argv[index][1];
+
+		switch (c) {
+		case 't':
+			_udp = false;
+			index++;
+			break;
+		case 'a':
+			index++;
+			_address = argv[index];
+			index++;
+			break;
+		case 'p':
+			index++;
+			_port = atoi(argv[index]);
+			index++;
+			break;		
+		case 'v':
+				_verbose = true;
+				index++;
+				break;
+		case 'h':
+			show_help();
+			exit(0);
+		default:
+			show_help();
+			exit(1);
+}
+
+	}
+
+
 #endif
 }
 
@@ -394,11 +750,12 @@ static void removeXcodeArgs(int *argc, char **argv) {
 	for (int i = 1; i < *argc; )
 	{
 		if (strcmp(argv[i], "-NSDocumentRevisionsDebugMode") == 0 ||
-			strcmp(argv[i], "-ApplePersistenceIgnoreState" ) == 0)
+			strcmp(argv[i], "-ApplePersistenceIgnoreState") == 0)
 		{
 			removeArg(i, argc, argv);
 			removeArg(i, argc, argv);
-		} else
+		}
+		else
 			++i;
 	}
 }
@@ -411,13 +768,13 @@ int main(int argc, char* argv[])
 	// Xcode sometimes adds additional arguments.
 	removeXcodeArgs(&argc, argv);
 #else
-	glutInit(&argc,argv);
+	glutInit(&argc, argv);
 #endif
 
 	init(argc, argv);
 	TuioDemo *app = new TuioDemo(_address.c_str(), _port, _udp, _verbose, _fullscreen);
 	app->run();
 	delete app;
-	
+
 	return 0;
 }

--- a/TuioDemo.h
+++ b/TuioDemo.h
@@ -1,6 +1,7 @@
 /*
  TUIO C++ GUI Demo
  Copyright (c) 2005-2016 Martin Kaltenbrunner <martin@tuio.org>
+ Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
  
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/TuioDemo.h
+++ b/TuioDemo.h
@@ -62,6 +62,37 @@ public:
 	void addTuioBlob(TuioBlob *tblb);
 	void updateTuioBlob(TuioBlob *tblb);
 	void removeTuioBlob(TuioBlob *tblb);
+
+
+
+
+	void addTuioObject25D(TuioObject25D *tobj);
+	void updateTuioObject25D(TuioObject25D *tobj);
+	void removeTuioObject25D(TuioObject25D *tobj);
+
+	void addTuioCursor25D(TuioCursor25D *tcur);
+	void updateTuioCursor25D(TuioCursor25D *tcur);
+	void removeTuioCursor25D(TuioCursor25D *tcur);
+
+	void addTuioBlob25D(TuioBlob25D *tblb);
+	void updateTuioBlob25D(TuioBlob25D *tblb);
+	void removeTuioBlob25D(TuioBlob25D *tblb);
+
+
+	void addTuioObject3D(TuioObject3D *tobj);
+	void updateTuioObject3D(TuioObject3D *tobj);
+	void removeTuioObject3D(TuioObject3D *tobj);
+
+	void addTuioCursor3D(TuioCursor3D *tcur);
+	void updateTuioCursor3D(TuioCursor3D *tcur);
+	void removeTuioCursor3D(TuioCursor3D *tcur);
+
+	void addTuioBlob3D(TuioBlob3D *tblb);
+	void updateTuioBlob3D(TuioBlob3D *tblb);
+	void removeTuioBlob3D(TuioBlob3D *tblb);
+
+
+
 	
 	void refresh(TuioTime frameTime);
 	

--- a/TuioDump.cpp
+++ b/TuioDump.cpp
@@ -2,7 +2,7 @@
 	TUIO C++ Example - part of the reacTIVision project
 	http://reactivision.sourceforge.net/
 
-	Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+	Copyright (c)
 
 	Permission is hereby granted, free of charge, to any person obtaining
 	a copy of this software and associated documentation files
@@ -41,7 +41,7 @@ void TuioDump::addTuioObject(TuioObject *tobj) {
 
 void TuioDump::updateTuioObject(TuioObject *tobj) {
 	std::cout << "set obj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/"<<  tobj->getTuioSourceID() << ") "<< tobj->getX() << " " << tobj->getY() << " " << tobj->getAngle() 
-				<< " " << tobj->getMotionSpeed() << " " << tobj->getRotationSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+		<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getRotationSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
 }
 
 void TuioDump::removeTuioObject(TuioObject *tobj) {
@@ -74,6 +74,94 @@ void TuioDump::removeTuioBlob(TuioBlob *tblb) {
 	std::cout << "del blb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/"<<  tblb->getTuioSourceID() << ")" << std::endl;
 }
 
+
+
+void TuioDump::addTuioObject25D(TuioObject25D *tobj) {
+	std::cout << "add 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getAngle() << std::endl;
+}
+
+void TuioDump::updateTuioObject25D(TuioObject25D *tobj) {
+	std::cout << "set 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getAngle()
+		<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRotationSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+}
+
+void TuioDump::removeTuioObject25D(TuioObject25D *tobj) {
+	std::cout << "del 25Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ")" << std::endl;
+}
+
+void TuioDump::addTuioCursor25D(TuioCursor25D *tcur) {
+	std::cout << "add 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ() << std::endl;
+}
+
+void TuioDump::updateTuioCursor25D(TuioCursor25D *tcur) {
+	std::cout << "set 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+		<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+}
+
+void TuioDump::removeTuioCursor25D(TuioCursor25D *tcur) {
+	std::cout << "del 25Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ")" << std::endl;
+}
+
+void TuioDump::addTuioBlob25D(TuioBlob25D *tblb) {
+	std::cout << "add 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea() << std::endl;
+}
+
+void TuioDump::updateTuioBlob25D(TuioBlob25D *tblb) {
+	std::cout << "set 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getAngle() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getArea()
+		<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRotationSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << std::endl;
+}
+
+void TuioDump::removeTuioBlob25D(TuioBlob25D *tblb) {
+	std::cout << "del 25Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ")" << std::endl;
+}
+
+
+
+
+void TuioDump::addTuioObject3D(TuioObject3D *tobj) {
+	std::cout << "add 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getRoll() << " " << tobj->getPitch() << " " << tobj->getYaw() << std::endl;
+}
+
+void TuioDump::updateTuioObject3D(TuioObject3D *tobj) {
+	std::cout << "set 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ") " << tobj->getX() << " " << tobj->getY() << " " << tobj->getZ() << " " << tobj->getRoll() << " " << tobj->getPitch() << " " << tobj->getYaw()
+		<< " " << tobj->getXSpeed() << " " << tobj->getYSpeed() << " " << tobj->getZSpeed() << " " << tobj->getRollSpeed() << " " << tobj->getPitchSpeed() << " " << tobj->getYawSpeed() << " " << tobj->getMotionAccel() << " " << tobj->getRotationAccel() << std::endl;
+}
+
+void TuioDump::removeTuioObject3D(TuioObject3D *tobj) {
+	std::cout << "del 3Dobj " << tobj->getSymbolID() << " (" << tobj->getSessionID() << "/" << tobj->getTuioSourceID() << ")" << std::endl;
+}
+
+void TuioDump::addTuioCursor3D(TuioCursor3D *tcur) {
+	std::cout << "add 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ() << std::endl;
+}
+
+void TuioDump::updateTuioCursor3D(TuioCursor3D *tcur) {
+	std::cout << "set 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ") " << tcur->getX() << " " << tcur->getY() << " " << tcur->getZ()
+		<< " " << tcur->getXSpeed() << " " << tcur->getYSpeed() << " " << tcur->getZSpeed() << " " << tcur->getMotionAccel() << " " << std::endl;
+}
+
+void TuioDump::removeTuioCursor3D(TuioCursor3D *tcur) {
+	std::cout << "del 3Dcur " << tcur->getCursorID() << " (" << tcur->getSessionID() << "/" << tcur->getTuioSourceID() << ")" << std::endl;
+}
+
+void TuioDump::addTuioBlob3D(TuioBlob3D *tblb) {
+	std::cout << "add 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getRoll() << " " << tblb->getPitch() << " " << tblb->getYaw() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getDepth() << " " << tblb->getVolume() << std::endl;
+}
+
+void TuioDump::updateTuioBlob3D(TuioBlob3D *tblb) {
+	std::cout << "set 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ") " << tblb->getX() << " " << tblb->getY() << " " << tblb->getZ() << " " << tblb->getRoll() << " " << tblb->getPitch() << " " << tblb->getYaw() << " " << tblb->getWidth() << " " << tblb->getHeight() << " " << tblb->getDepth() << " " << tblb->getVolume()
+		<< " " << tblb->getXSpeed() << " " << tblb->getYSpeed() << " " << tblb->getZSpeed() << " " << tblb->getRollSpeed() << " " << tblb->getPitchSpeed() << " " << tblb->getYawSpeed() << " " << tblb->getMotionAccel() << " " << tblb->getRotationAccel() << std::endl;
+}
+
+void TuioDump::removeTuioBlob3D(TuioBlob3D *tblb) {
+	std::cout << "del 3Dblb " << tblb->getBlobID() << " (" << tblb->getSessionID() << "/" << tblb->getTuioSourceID() << ")" << std::endl;
+}
+
+
+
+
+
+
 void  TuioDump::refresh(TuioTime frameTime) {
 	//std::cout << "refresh " << frameTime.getTotalMilliseconds() << std::endl;
 }
@@ -87,6 +175,8 @@ static void show_help() {
 	std::cout << "           use 'incoming' for TUIO/TCP socket" << std::endl;
 	std::cout << "        -h show this help" << std::endl;
 }
+
+
 
 static void init(int argc, char** argv) {
 	char c;
@@ -111,6 +201,39 @@ static void init(int argc, char** argv) {
 				exit(1);
 		}
 	}
+#else
+
+	int index = 1;
+
+	while (index < argc)
+	{
+		c = argv[index][1];
+
+		switch (c) {
+			case 't':
+				_udp = false;
+				index++;
+				break;
+			case 'a':
+				index++;
+				_address = argv[index];
+				index++;
+				break;
+			case 'p':
+				index++;
+				_port = atoi(argv[index]);
+				index++;
+				break;
+			case 'h':
+				show_help();
+				exit(0);
+			default:
+				show_help();
+				exit(1);
+		}
+
+	}
+
 #endif
 }
 

--- a/TuioDump.cpp
+++ b/TuioDump.cpp
@@ -1,8 +1,8 @@
 /*
 	TUIO C++ Example - part of the reacTIVision project
 	http://reactivision.sourceforge.net/
-
-	Copyright (c)
+	Copyright (c) 2005-2017 Martin Kaltenbrunner <martin@tuio.org>
+	Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
 	Permission is hereby granted, free of charge, to any person obtaining
 	a copy of this software and associated documentation files
@@ -11,14 +11,11 @@
 	publish, distribute, sublicense, and/or sell copies of the Software,
 	and to permit persons to whom the Software is furnished to do so,
 	subject to the following conditions:
-
 	The above copyright notice and this permission notice shall be
 	included in all copies or substantial portions of the Software.
-
 	Any person wishing to distribute modifications to the Software is
 	requested to send the modifications to the original developer so that
 	they can be incorporated into the canonical version.
-
 	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 	EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 	MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.

--- a/TuioDump.h
+++ b/TuioDump.h
@@ -53,6 +53,31 @@ class TuioDump : public TuioListener {
 		void updateTuioBlob(TuioBlob *tblb);
 		void removeTuioBlob(TuioBlob *tblb);
 
+		void addTuioObject25D(TuioObject25D *tobj);
+		void updateTuioObject25D(TuioObject25D *tobj);
+		void removeTuioObject25D(TuioObject25D *tobj);
+
+		void addTuioCursor25D(TuioCursor25D *tcur);
+		void updateTuioCursor25D(TuioCursor25D *tcur);
+		void removeTuioCursor25D(TuioCursor25D *tcur);
+
+		void addTuioBlob25D(TuioBlob25D *tblb);
+		void updateTuioBlob25D(TuioBlob25D *tblb);
+		void removeTuioBlob25D(TuioBlob25D *tblb);
+
+
+		void addTuioObject3D(TuioObject3D *tobj);
+		void updateTuioObject3D(TuioObject3D *tobj);
+		void removeTuioObject3D(TuioObject3D *tobj);
+
+		void addTuioCursor3D(TuioCursor3D *tcur);
+		void updateTuioCursor3D(TuioCursor3D *tcur);
+		void removeTuioCursor3D(TuioCursor3D *tcur);
+
+		void addTuioBlob3D(TuioBlob3D *tblb);
+		void updateTuioBlob3D(TuioBlob3D *tblb);
+		void removeTuioBlob3D(TuioBlob3D *tblb);
+
 		void refresh(TuioTime frameTime);
 };
 

--- a/TuioDump.h
+++ b/TuioDump.h
@@ -2,6 +2,7 @@
 	TUIO C++ Example - part of the reacTIVision project
 	http://reactivision.sourceforge.net/
 	Copyright (c) 2005-2016 Martin Kaltenbrunner <martin@tuio.org>
+	Modified by Bremard Nicolas <nicolas@bremard.fr> on 11/2022
 
 	Permission is hereby granted, free of charge, to any person obtaining
 	a copy of this software and associated documentation files

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,26 @@ Pressing the CTRL key while clicking, will create "joint" cursors.
 Hitting the V key will print the generated TUIO events to the console.  
 Hitting the R key will reset the SimpleSimulator.
 
+You can switch to other TUIO types by hitting number :
+0 : TuioCursor;
+1 : TuioObject;
+2 : TuioBlob;
+3 : TuioCursor25D;
+4 : TuioObject25D;
+5 : TuioBlob25D;
+6 : TuioCursor3D;
+7 : TuioObject3D;
+8 : TuioBlob3D.
+
+As the SimpleSimulatro demo is a 2D application, is it diffcult to test rotations, z, width ... You can modify them by scrolling in different control mode. Each control mode change a different parameter. You can switch control mode by hitting number on the NumPad :
+0 : Z;
+1 : Roll;
+2 : Pitch;
+3 : Yaw;
+4 : Width;
+5 : Height;
+6 : Depth;
+
 Keep in mind to make your graphics scalable for the varying screen and 
 window resolutions. A reasonable TUIO application will run in fullscreen 
 mode, although the windowed mode might be useful for debugging purposes 
@@ -75,6 +95,48 @@ surface
 *   **updateTuioBlob(TuioBlob \*tblb)** a cursor was moving on the table 
 surface
 
+*   **addTuioObject25D(TuioObject25D \*tobj)** this is called when a 25Dobject 
+becomes visible
+*   **removeTuioObject25D(TuioObject25D \*tobj)** a 25Dobject was removed from 
+the surface
+*   **updateTuioObject25D(TuioObject25D \*tobj)** a 25Dobject was moved on the 
+table surface
+
+*   **addTuioCursor25D(TuioCursor25D \*tcur)** this is called when a new 25Dcursor 
+is detected
+*   **removeTuioCursor25D(TuioCursor25D \*tcur)** a 25Dcursor was removed from the 
+surface
+*   **updateTuioCursor25D(TuioCursor25D \*tcur)** a 25Dcursor was moving on the 
+table surface
+
+*   **addTuioBlob25D(TuioBlob25D \*tblb)** this is called when a new 25Dblob is 
+detected
+*   **removeTuioBlob25D(TuioBlob25D \*tblb)** a 25Dblob was removed from the 
+surface
+*   **updateTuioBlob25D(TuioBlob25D \*tblb)** a 25Dcursor was moving on the table 
+surface
+
+*   **addTuioObject3D(TuioObject3D \*tobj)** this is called when a 3Dobject 
+becomes visible
+*   **removeTuioObject3D(TuioObject3D \*tobj)** a 3Dobject was removed from 
+the surface
+*   **updateTuioObject3D(TuioObject3D \*tobj)** a 3Dobject was moved on the 
+table surface
+
+*   **addTuioCursor3D(TuioCursor3D \*tcur)** this is called when a new 3Dcursor 
+is detected
+*   **removeTuioCursor3D(TuioCursor3D \*tcur)** a 3Dcursor was removed from the 
+surface
+*   **updateTuioCursor3D(TuioCursor3D \*tcur)** a 3Dcursor was moving on the 
+table surface
+
+*   **addTuioBlob3D(TuioBlob3D \*tblb)** this is called when a new 3Dblob is 
+detected
+*   **removeTuioBlob3D(TuioBlob3D \*tblb)** a 3Dblob was removed from the 
+surface
+*   **updateTuioBlob3D(TuioBlob3D \*tblb)** a 3Dblob was moving on the table 
+surface
+
 *   **refresh(TuioTime bundleTime)** this method is called after each 
 bundle, use it to repaint your screen for example
 
@@ -92,20 +154,18 @@ ID that corresponds to its attached fiducial marker number. The finger
 ID of the cursor object is always a number in the range of all currently 
 detected cursor blobs.
 
-The **TuioObject**, **TuioCursor** and **TuioBlob** references are 
+The **TuioObject**, **TuioCursor**, **TuioBlob**,**TuioObject25D**, **TuioCursor25D**, **TuioBlob25D**,**TuioObject3D**, **TuioCursor3D** and **TuioBlob3D** references are 
 updated automatically by the TuioClient and are always referencing the 
-same instance over the object lifetime. All the TuioObject, TuioCursor 
-and TuioBlob attributes are encapsulated and can be accessed with 
+same instance over the object lifetime. All the TuioObject, TuioCursor, TuioBlob, TuioObject25D, TuioCursor25D, TuioBlob25D, TuioObject3D, TuioCursor3D and TuioBlob3D attributes are encapsulated and can be accessed with 
 methods such as **getX()**, **getY()** and **getAngle()** and so on. 
-TuioObject, TuioCursor and TuioBlob also have some additional 
+TuioObject, TuioCursor, TuioBlob, TuioObject25D, TuioCursor25D, TuioBlob25D, TuioObject3D, TuioCursor3D and TuioBlob3D also have some additional 
 convenience methods for the calculation of distances and angles between 
 objects. The **getPath()** method returns a Vector of TuioPoint 
 representing the movement path of the object.
 
 Alternatively the TuioClient class contains some methods for the polling 
 of the current object and cursor state. There are methods which return 
-either a list or individual object and cursor objects. The TuioObject, 
-TuioCursor and TuioBlob classes have been added as a container which 
+either a list or individual object and cursor objects. The TuioObject, TuioCursor, TuioBlob, TuioObject25D, TuioCursor25D, TuioBlob25D, TuioObject3D, TuioCursor3D and TuioBlob3D classes have been added as a container which 
 also can be usedby external classes.
 
 *   **getTuioObjects()** returns a Vector<TuioObject*> of all currently 
@@ -121,6 +181,37 @@ on its presence
 on its presence
 *   **getTuioBlob(long s_id)** returns a TuioBlob* or NULL depending on 
 its presence
+
+
+*   **getTuioObjects25D()** returns a Vector<TuioObject25D*> of all currently 
+present TuioObjects25D
+*   **getTuioCursors25D()** returns a Vector<TuioCursor25D*> of all currently 
+present TuioCursors25D
+*   **getTuioBlobs25D()** returns a Vector<TuioBlob25D*> of all currently 
+present TuioCursors25D
+
+*   **getTuioObject25D(long s_id)** returns a TuioObject25D* or NULL depending 
+on its presence
+*   **getTuioCursor25D(long s_id)** returns a TuioCursor25D* or NULL depending 
+on its presence
+*   **getTuioBlob25D(long s_id)** returns a TuioBlob25D* or NULL depending on 
+its presence
+
+
+*   **getTuioObjects3D()** returns a Vector<TuioObject3D*> of all currently 
+present TuioObjects3D
+*   **getTuioCursors3D()** returns a Vector<TuioCursor3D*> of all currently 
+present TuioCursors3D
+*   **getTuioBlobs3D()** returns a Vector<TuioBlob3D*> of all currently 
+present TuioCursors3D
+
+*   **getTuioObject3D(long s_id)** returns a TuioObject* or NULL depending 
+on its presence
+*   **getTuioCursor3D(long s_id)** returns a TuioCursor* or NULL depending 
+on its presence
+*   **getTuioBlob3D(long s_id)** returns a TuioBlob* or NULL depending on 
+its presence
+
 
 ## Building the Examples:
 

--- a/windows/SimpleSimulator.vcxproj
+++ b/windows/SimpleSimulator.vcxproj
@@ -22,12 +22,12 @@
     <ProjectGuid>{810E065A-EC96-4C3F-8C8B-7EAE285DC797}</ProjectGuid>
     <RootNamespace>SimpleSimulator</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v110</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>

--- a/windows/SimpleSimulator.vcxproj
+++ b/windows/SimpleSimulator.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -22,28 +22,29 @@
     <ProjectGuid>{810E065A-EC96-4C3F-8C8B-7EAE285DC797}</ProjectGuid>
     <RootNamespace>SimpleSimulator</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/windows/TuioDemo.vcxproj
+++ b/windows/TuioDemo.vcxproj
@@ -22,23 +22,24 @@
     <ProjectGuid>{8737A4B6-C44F-4397-9BB5-432646375E9F}</ProjectGuid>
     <RootNamespace>TuioDemo</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/windows/TuioDemo.vcxproj
+++ b/windows/TuioDemo.vcxproj
@@ -22,12 +22,12 @@
     <ProjectGuid>{8737A4B6-C44F-4397-9BB5-432646375E9F}</ProjectGuid>
     <RootNamespace>TuioDemo</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v110</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>

--- a/windows/TuioDump.vcxproj
+++ b/windows/TuioDump.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -22,28 +22,29 @@
     <ProjectGuid>{5E2EAE4F-8668-4647-98CA-562358EACC10}</ProjectGuid>
     <RootNamespace>TuioDump</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -147,7 +148,7 @@
     <Link>
       <AdditionalDependencies>msvcrt.lib;libcpmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)TuioDump.exe</OutputFile>
-      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>
@@ -172,7 +173,7 @@
     <Link>
       <AdditionalDependencies>msvcrt.lib;libcpmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)TuioDump.exe</OutputFile>
-      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/windows/TuioDump.vcxproj
+++ b/windows/TuioDump.vcxproj
@@ -22,12 +22,12 @@
     <ProjectGuid>{5E2EAE4F-8668-4647-98CA-562358EACC10}</ProjectGuid>
     <RootNamespace>TuioDump</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v110</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
@@ -148,7 +148,7 @@
     <Link>
       <AdditionalDependencies>msvcrt.lib;libcpmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>$(OutDir)TuioDump.exe</OutputFile>
-      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/windows/TuioDump.vcxproj.user
+++ b/windows/TuioDump.vcxproj.user
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
 </Project>

--- a/windows/libTUIO.vcxproj
+++ b/windows/libTUIO.vcxproj
@@ -22,31 +22,32 @@
     <ProjectGuid>{E1C28E7D-466C-4D0A-AEB1-CFFD0F6F5645}</ProjectGuid>
     <RootNamespace>libTUIO</RootNamespace>
     <Keyword>ManagedCProj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>false</CLRSupport>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>false</CLRSupport>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>false</CLRSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>false</CLRSupport>
   </PropertyGroup>
@@ -222,6 +223,13 @@
     <ClCompile Include="..\TUIO\UdpReceiver.cpp" />
     <ClCompile Include="..\TUIO\UdpSender.cpp" />
     <ClCompile Include="..\TUIO\WebSockSender.cpp" />
+    <ClCompile Include="..\TUIO\TuioBlob25D.cpp" />
+    <ClCompile Include="..\TUIO\TuioBlob3D.cpp" />
+    <ClCompile Include="..\TUIO\TuioCursor25D.cpp" />
+    <ClCompile Include="..\TUIO\TuioCursor3D.cpp" />
+    <ClCompile Include="..\TUIO\TuioObject25D.cpp" />
+    <ClCompile Include="..\TUIO\TuioObject3D.cpp" />
+    <ClCompile Include="..\TUIO\TuioCustom.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\oscpack\ip\NetworkingUtils.h" />
@@ -254,6 +262,13 @@
     <ClInclude Include="..\TUIO\UdpReceiver.h" />
     <ClInclude Include="..\TUIO\UdpSender.h" />
     <ClInclude Include="..\TUIO\WebSockSender.h" />
+    <ClInclude Include="..\TUIO\TuioBLob25D.h" />
+    <ClInclude Include="..\TUIO\TuioBlob3D.h" />
+    <ClInclude Include="..\TUIO\TuioCursor25D.h" />
+    <ClInclude Include="..\TUIO\TuioCursor3D.h" />
+    <ClInclude Include="..\TUIO\TuioObject25D.h" />
+    <ClInclude Include="..\TUIO\TuioObject3D.h" />
+    <ClInclude Include="..\TUIO\TuioCustom.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/windows/libTUIO.vcxproj
+++ b/windows/libTUIO.vcxproj
@@ -22,12 +22,12 @@
     <ProjectGuid>{E1C28E7D-466C-4D0A-AEB1-CFFD0F6F5645}</ProjectGuid>
     <RootNamespace>libTUIO</RootNamespace>
     <Keyword>ManagedCProj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v110</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>false</CLRSupport>
     <WholeProgramOptimization>true</WholeProgramOptimization>

--- a/windows/libTUIO.vcxproj
+++ b/windows/libTUIO.vcxproj
@@ -145,7 +145,7 @@
       <AdditionalIncludeDirectories>..\TUIO;..\oscpack;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;LIB_EXPORT;OSC_HOST_LITTLE_ENDIAN;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES
 ;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>false</FunctionLevelLinking>
       <PrecompiledHeader />
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
@@ -229,7 +229,6 @@
     <ClCompile Include="..\TUIO\TuioCursor3D.cpp" />
     <ClCompile Include="..\TUIO\TuioObject25D.cpp" />
     <ClCompile Include="..\TUIO\TuioObject3D.cpp" />
-    <ClCompile Include="..\TUIO\TuioCustom.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\oscpack\ip\NetworkingUtils.h" />
@@ -268,7 +267,6 @@
     <ClInclude Include="..\TUIO\TuioCursor3D.h" />
     <ClInclude Include="..\TUIO\TuioObject25D.h" />
     <ClInclude Include="..\TUIO\TuioObject3D.h" />
-    <ClInclude Include="..\TUIO\TuioCustom.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/windows/libTUIO.vcxproj.filters
+++ b/windows/libTUIO.vcxproj.filters
@@ -95,6 +95,27 @@
     <ClCompile Include="..\TUIO\WebSockSender.cpp">
       <Filter>Source Files\TUIO</Filter>
     </ClCompile>
+    <ClCompile Include="..\TUIO\TuioBlob3D.cpp">
+      <Filter>Source Files\TUIO</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TUIO\TuioBlob25D.cpp">
+      <Filter>Source Files\TUIO</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TUIO\TuioCursor3D.cpp">
+      <Filter>Source Files\TUIO</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TUIO\TuioCursor25D.cpp">
+      <Filter>Source Files\TUIO</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TUIO\TuioObject3D.cpp">
+      <Filter>Source Files\TUIO</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TUIO\TuioObject25D.cpp">
+      <Filter>Source Files\TUIO</Filter>
+    </ClCompile>
+    <ClCompile Include="..\TUIO\TuioCustom.cpp">
+      <Filter>Source Files\TUIO</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\TUIO\FlashSender.h">
@@ -186,6 +207,27 @@
     </ClInclude>
     <ClInclude Include="..\oscpack\ip\UdpSocket.h">
       <Filter>Header Files\oscpack</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TUIO\TuioObject3D.h">
+      <Filter>Header Files\TUIO</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TUIO\TuioObject25D.h">
+      <Filter>Header Files\TUIO</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TUIO\TuioBlob3D.h">
+      <Filter>Header Files\TUIO</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TUIO\TuioBLob25D.h">
+      <Filter>Header Files\TUIO</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TUIO\TuioCursor3D.h">
+      <Filter>Header Files\TUIO</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TUIO\TuioCursor25D.h">
+      <Filter>Header Files\TUIO</Filter>
+    </ClInclude>
+    <ClInclude Include="..\TUIO\TuioCustom.h">
+      <Filter>Header Files\TUIO</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/windows/libTUIO.vcxproj.filters
+++ b/windows/libTUIO.vcxproj.filters
@@ -113,9 +113,6 @@
     <ClCompile Include="..\TUIO\TuioObject25D.cpp">
       <Filter>Source Files\TUIO</Filter>
     </ClCompile>
-    <ClCompile Include="..\TUIO\TuioCustom.cpp">
-      <Filter>Source Files\TUIO</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\TUIO\FlashSender.h">
@@ -224,9 +221,6 @@
       <Filter>Header Files\TUIO</Filter>
     </ClInclude>
     <ClInclude Include="..\TUIO\TuioCursor25D.h">
-      <Filter>Header Files\TUIO</Filter>
-    </ClInclude>
-    <ClInclude Include="..\TUIO\TuioCustom.h">
       <Filter>Header Files\TUIO</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Hello,
I added everything needed for implementing 2.5D and 3D included in the TUIO protocol.
That includes : 
- 2.5D blob class
- 3D blob class
- 2.5D object class
- 3D object class
- 2.5D cursor class
- 3D cursor class
- callbacks
- send functions

No modifications on 2D, so 2D messages can be received by older version of TUIO 1.1 and this version can receive 2D messages from older versions.

I called it 1.1.7, as previous one was 1.1.6

Regards

Bremard Nicolas